### PR TITLE
[13.0][FIX] stock_warehouse_partner_security: inventory mode resolution breaks non-inventory operations

### DIFF
--- a/stock_warehouse_partner_security/models/stock_quant.py
+++ b/stock_warehouse_partner_security/models/stock_quant.py
@@ -44,6 +44,9 @@ class StockQuant(models.Model):
             
     @api.model
     def _is_inventory_mode(self):
-        return super()._is_inventory_mode() or self.user_has_groups(
-            'stock_warehouse_partner_security.group_stock_picking_partner'
+        return super()._is_inventory_mode() or (
+            self.env.context.get('inventory_mode') is True 
+            and self.user_has_groups(
+                'stock_warehouse_partner_security.group_stock_picking_partner'
+            )
         )

--- a/stock_warehouse_partner_security/views/stock_warehouse_partner_security_menus.xml
+++ b/stock_warehouse_partner_security/views/stock_warehouse_partner_security_menus.xml
@@ -17,6 +17,25 @@
             <field name="search_view_id" ref="stock.view_picking_internal_search"/>
         </record>
 
+        <!-- 
+            Quants action for group_stock_picking_partner new menu, forces
+             inventory mode
+            Imported from stock.action_view_quants + inventory mode enabled 
+        -->
+        <record model="ir.actions.server" id="action_view_quants">
+            <field name="name">Inventory (in stock_warehouse_partner_security)</field>
+            <field name="model_id" ref="model_stock_quant"/>
+            <field name="state">code</field>
+            <field name="code">
+                action = model.with_context(
+                    search_default_internal_loc=1,
+                    search_default_productgroup=1,
+                    search_default_locationgroup=1,
+                    inventory_mode=True,
+                ).action_view_quants()
+            </field>
+        </record>
+
         <menuitem id="menu_myoperations" name="My Operations"
               parent="stock.menu_stock_root" sequence="1"
               groups="group_stock_picking_partner"/>
@@ -28,7 +47,7 @@
 
         <menuitem id="menu_valuation" name="My Inventory Report"
               parent="menu_myoperations" sequence="20"
-              action="stock.action_view_quants"
+              action="action_view_quants"
               groups="group_stock_picking_partner"/>
 
     </data>


### PR DESCRIPTION
Previous to this fix, some internal operations were incorrectly identified as "inventory mode" operations.

To fix it, inventory mode resolution is properly coded. A custom action for "My Inventory Report" menu is needed now
