### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: enable user defined custom date management for purchase orders

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.2.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/purchase_order.py
+++ b/stock_picking_mgmt_weight/models/purchase_order.py
@@ -118,6 +118,11 @@ class PurchaseOrder(models.Model):
         compute="_compute_classification_invoice_ids"
     )
 
+    propagate_custom_date = fields.Boolean(
+        default=False,
+        help="Technical field for order date propagation to stock moves",
+    )
+
     def _compute_classification_invoice_ids(self):
         for record in self:
             lines = record.classification_order_ids.invoice_ids.invoice_line_ids.filtered(

--- a/stock_picking_mgmt_weight/models/stock_picking.py
+++ b/stock_picking_mgmt_weight/models/stock_picking.py
@@ -145,7 +145,11 @@ class StockPicking(models.Model):
         #      action_done() maybe is better, but is multi
         self.ensure_one()
         stock_move_custom_date = False
-        if self.purchase_id and self.purchase_id.classification:
+        if self.purchase_id and (
+            self.purchase_id.classification
+            or
+            self.purchase_id.propagate_custom_date
+        ):
             stock_move_custom_date = self.scheduled_date
         picking = self.with_context(
             stock_move_custom_date=stock_move_custom_date

--- a/stock_picking_mgmt_weight/views/purchase_order_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_views.xml
@@ -75,6 +75,10 @@
                     widget="many2many_tags"
                     attrs="{'invisible': [('classification', '=', False)]}"
                 />
+                <field
+                    name="propagate_custom_date"
+                    groups="base.group_no_one"
+                />
             </xpath>
             <xpath expr="//form/group/group/field[@name='product_id']" position="after">
                 <field


### PR DESCRIPTION
With this improvement, the current functionality that passes purchase order date to its stock moves, is now available for all orders, only in debug mode can be enabled