### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: filter order lines by order state in classification wizard

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.4.0",
+    "version": "13.0.1.4.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/wizards/move_line_weight_views.xml
+++ b/stock_picking_mgmt_weight/wizards/move_line_weight_views.xml
@@ -17,7 +17,7 @@
                         ('product_id','!=',False),
                         ('product_id.type','=','product'),
                         ('order_id.classification','=',False),
-                        ('state','=','purchase'),
+                        ('order_id.state','=','purchase'),
                         ('pending_qty','&gt;',0),]" 
                     options="{'no_create': True}"/>
                 <field name="product_id" options="{'no_create': True}"/>


### PR DESCRIPTION
Sometimes order lines state is not fully coherent with order one. With this fix every order line is selectable in classification wizard when order state is "purchase", even if its state is different.