### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: sale order pending quantities cancellation

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.8.0",
+    "version": "13.0.1.9.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [
@@ -25,6 +25,7 @@
         "purchase_pricelist_slv",
         "stock_move_action_done_custdate",
         "account_payment_term_base_date",
+        "sale_stock",
         "sale_order_line_menu",
         "base_model_code_mixin",
     ],

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-07 08:22+0000\n"
-"PO-Revision-Date: 2022-04-07 08:22+0000\n"
+"POT-Creation-Date: 2022-05-19 07:19+0000\n"
+"PO-Revision-Date: 2022-05-19 07:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -172,24 +172,32 @@ msgstr "Cancelar"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.actions.server,name:stock_picking_mgmt_weight.action_purchase_order_cancel_pending
+#: model:ir.actions.server,name:stock_picking_mgmt_weight.action_sale_order_cancel_pending_multi
 msgid "Cancel Pending"
 msgstr "Cancelar pendiente"
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancel pending"
 msgstr "Cancelar pendiente"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__qty_cancelled
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancelled"
-msgstr "Cancelada"
+msgstr "Cancelado"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order__cancelled_classif_count
 msgid "Cancelled Classif Count"
 msgstr "Nº Clasificaciones canceladas"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__qty_cancelled
+msgid "Cancelled Quantity"
+msgstr "Cantidad cancelada"
 
 #. module: stock_picking_mgmt_weight
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
@@ -621,6 +629,8 @@ msgstr "Bruto:"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order__has_pending_qty
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order__has_pending_qty
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__has_pending_qty
 msgid "Has Pending Qty"
 msgstr "Tiene cantidades pendientes"
 
@@ -682,6 +692,7 @@ msgstr "Entrada"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_purchase_order__has_pending_qty
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order__has_pending_qty
 msgid ""
 "Instrumental field indicating if there's any pending quantity for this order"
 msgstr ""
@@ -1005,6 +1016,7 @@ msgstr "Pend. rec."
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.ui.menu,name:stock_picking_mgmt_weight.menu_mgmt_weight_pending_classif
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
@@ -1018,8 +1030,12 @@ msgstr "Clasificaciones Pendientes"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__pending_qty
-#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__pending_qty
 msgid "Pending Qty"
+msgstr "Cantidad Pendiente"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__pending_qty
+msgid "Pending Quantity"
 msgstr "Cantidad Pendiente"
 
 #. module: stock_picking_mgmt_weight
@@ -1037,7 +1053,7 @@ msgstr "Clasificación de albarán"
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_stock_picking_type
 msgid "Picking Type"
-msgstr "Tipo de albarán"
+msgstr "Tipo de Albarán"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.actions.report,name:stock_picking_mgmt_weight.action_report_move_tag
@@ -1135,6 +1151,11 @@ msgstr "Cantidad"
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Qty Classified"
 msgstr "Clasificada"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order_line__qty_cancelled
+msgid "Quantities affected by 'Cancel Pending' process"
+msgstr "Cantidades afectadas por el proceso de 'Cancelar pendiente'"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
@@ -1367,6 +1388,11 @@ msgstr ""
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_purchase_order_line__price_unit_wd
 msgid "Technical field for pending invoicing amount data"
 msgstr "Campo técnico para cálculo de importes pendientes de facturar"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order_line__has_pending_qty
+msgid "Technical field for sale order has pending quantity computation"
+msgstr "Campo técnico para el cálculo de si tiene cantidad pendiente el pedido de venta"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move__theoretical_qty

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-07 08:21+0000\n"
-"PO-Revision-Date: 2022-04-07 08:21+0000\n"
+"POT-Creation-Date: 2022-05-19 07:17+0000\n"
+"PO-Revision-Date: 2022-05-19 07:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -160,16 +160,19 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.actions.server,name:stock_picking_mgmt_weight.action_purchase_order_cancel_pending
+#: model:ir.actions.server,name:stock_picking_mgmt_weight.action_sale_order_cancel_pending_multi
 msgid "Cancel Pending"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancel pending"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__qty_cancelled
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancelled"
 msgstr ""
@@ -177,6 +180,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order__cancelled_classif_count
 msgid "Cancelled Classif Count"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__qty_cancelled
+msgid "Cancelled Quantity"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -595,6 +603,8 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order__has_pending_qty
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order__has_pending_qty
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__has_pending_qty
 msgid "Has Pending Qty"
 msgstr ""
 
@@ -656,6 +666,7 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_purchase_order__has_pending_qty
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order__has_pending_qty
 msgid ""
 "Instrumental field indicating if there's any pending quantity for this order"
 msgstr ""
@@ -977,6 +988,7 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.ui.menu,name:stock_picking_mgmt_weight.menu_mgmt_weight_pending_classif
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
@@ -990,8 +1002,12 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__pending_qty
-#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__pending_qty
 msgid "Pending Qty"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__pending_qty
+msgid "Pending Quantity"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1104,6 +1120,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__qty_classified
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Qty Classified"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order_line__qty_cancelled
+msgid "Quantities affected by 'Cancel Pending' process"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1336,6 +1357,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_purchase_order_line__price_unit_wd
 msgid "Technical field for pending invoicing amount data"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order_line__has_pending_qty
+msgid "Technical field for sale order has pending quantity computation"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/models/sale_order.py
+++ b/stock_picking_mgmt_weight/models/sale_order.py
@@ -7,7 +7,43 @@ from odoo import fields, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    has_pending_qty = fields.Boolean(
+        compute="_compute_has_pending_qty",
+        help="Instrumental field indicating if there's any pending quantity"
+        " for this order",
+    )
     shipping_resource_id = fields.Many2one(
         comodel_name="shipping.resource",
         default=lambda self: self.env["shipping.resource"].get_default(),
     )
+
+    def _compute_has_pending_qty(self):
+        for record in self:
+            record.has_pending_qty = any([
+                line.has_pending_qty for line in record.order_line
+            ])
+
+    def action_cancel_pending(self):
+        """
+        Finishes selected orders, cancelling pending quantities.
+        Pending pickings are cancelled as result of this process, not vice versa
+        """
+        # An error is not raised due to batch action with several orders launch
+        # In that case, if orders with no pending quantities are selected, this
+        #  process is simply ignored
+        if not self.has_pending_qty:
+            return
+
+        pending_lines = self.order_line.filtered(lambda x: x.has_pending_qty)
+        for line in pending_lines:
+            # TODO better get it from to-cancel pickings?
+            line.qty_cancelled += line.pending_qty
+
+        cancel_pickings = pending_lines.mapped(
+            "move_ids.picking_id"
+        ).filtered(lambda x: x.state not in ["done", "cancel"])
+        cancel_pickings.action_cancel()
+
+    def action_cancel_pending_multi(self):
+        for record in self.browse(self.env.context["active_ids"]):
+            record.action_cancel_pending()

--- a/stock_picking_mgmt_weight/models/sale_order_line.py
+++ b/stock_picking_mgmt_weight/models/sale_order_line.py
@@ -2,21 +2,46 @@
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
 from odoo import fields, models, api
+from odoo.tools.float_utils import float_compare
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    qty_cancelled = fields.Float(
+        digits="Product Unit of Measure",
+        string="Cancelled Quantity",
+        readonly=True,
+        help="Quantities affected by 'Cancel Pending' process",
+    )
     pending_qty = fields.Float(
         compute="_compute_pending_qty",
+        string="Pending Quantity",
         digits="Product Unit of Measure",
-        store=True
+        store=True,
+    )
+    has_pending_qty = fields.Boolean(
+        compute="_compute_pending_qty",
+        store=True,
+        readonly=True,
+        help="Technical field for sale order has pending quantity computation",
     )
 
     supply_condition_id = fields.Many2one(comodel_name="supply.condition")
     vehicle_type_id = fields.Many2one(comodel_name="vehicle.type")
 
-    @api.depends('product_uom_qty', 'qty_delivered')
+    @api.depends("product_uom_qty", "qty_delivered", "qty_cancelled")
     def _compute_pending_qty(self):
         for line in self:
-            line.pending_qty = line.product_uom_qty - line.qty_delivered
+            line.pending_qty = (
+                line.product_uom_qty - line.qty_delivered - line.qty_cancelled
+            )
+            # We only take in account positive pending quantities
+            #  (it's possible to be negative)
+            line.has_pending_qty = (
+                float_compare(
+                    line.pending_qty,
+                    0,
+                    precision_rounding=line.product_uom.rounding or 0.001
+                ) == 1
+            )

--- a/stock_picking_mgmt_weight/views/sale_order_views.xml
+++ b/stock_picking_mgmt_weight/views/sale_order_views.xml
@@ -5,6 +5,18 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='action_draft']" position="before">
+                <field name="has_pending_qty" invisible="1"/>                
+                <button name="action_cancel_pending"
+                    type="object"
+                    string="Cancel pending"
+                    attrs="{'invisible': [
+                        '|',
+                        ('state','not in',['sale','done','cancel']),
+                        ('has_pending_qty','=',False)
+                    ]}"
+                />
+            </xpath>
             <xpath expr="//group[@name='sale_shipping']" position="inside">
                 <field
                     name="shipping_resource_id"
@@ -47,6 +59,31 @@
                     options="{'no_create_edit': True, 'no_create': True}"
                 />
             </xpath>        
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='qty_delivered']"
+                position="after"
+            >
+                <field name="qty_cancelled" string="Cancelled" />
+                <field name="pending_qty" string="Pending" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='qty_delivered']"
+                position="after"
+            >
+                <field name="qty_cancelled" optional="show" string="Cancelled" />
+                <field name="pending_qty" optional="hide" string="Pending" />
+            </xpath>
         </field>
     </record>
+
+    <record id="action_sale_order_cancel_pending_multi" model="ir.actions.server">
+        <field name="name">Cancel Pending</field>
+        <field name="model_id" ref="model_sale_order"/>
+        <field name="binding_model_id" ref="sale.model_sale_order" />
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = model.action_cancel_pending_multi()
+        </field> 
+    </record>    
 </odoo>


### PR DESCRIPTION
With this improvement, a basic sale order pending quantities cancellation is provided:
* The process is for the whole order, not line per line.
* Pending pickings are cancelled.
* Pending quantity for a line will take in account cancel quantity
* Subsquent order operations (such as adding a new line or increasing line quantity) should lead to inconsistent information.

@ChristianSantamaria could you update test environment with this improvement? Thanks!