### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: sale & purchase line improvements

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.10.0",
+    "version": "13.0.1.11.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.11.0",
+    "version": "13.0.1.12.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-19 07:19+0000\n"
-"PO-Revision-Date: 2022-05-19 07:19+0000\n"
+"POT-Creation-Date: 2022-06-01 17:16+0000\n"
+"PO-Revision-Date: 2022-06-01 17:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -185,9 +185,11 @@ msgstr "Cancelar pendiente"
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__qty_cancelled
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancelled"
-msgstr "Cancelado"
+msgstr "Cancelada"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order__cancelled_classif_count
@@ -1392,7 +1394,9 @@ msgstr "Campo técnico para cálculo de importes pendientes de facturar"
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order_line__has_pending_qty
 msgid "Technical field for sale order has pending quantity computation"
-msgstr "Campo técnico para el cálculo de si tiene cantidad pendiente el pedido de venta"
+msgstr ""
+"Campo técnico para el cálculo de si tiene cantidad pendiente el pedido de "
+"venta"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move__theoretical_qty
@@ -1504,8 +1508,13 @@ msgstr "Importe total pendiente de facturar"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+msgid "Total cancelled quantity"
+msgstr "Total cantidad cancelada"
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
 msgid "Total pending quantity"
-msgstr ""
+msgstr "Total cantidad pendiente"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.purchase_order_view_tree

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-19 07:17+0000\n"
-"PO-Revision-Date: 2022-05-19 07:17+0000\n"
+"POT-Creation-Date: 2022-06-01 17:15+0000\n"
+"PO-Revision-Date: 2022-06-01 17:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -173,6 +173,8 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__qty_cancelled
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancelled"
 msgstr ""
@@ -1463,6 +1465,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.purchase_order_view_tree
 msgid "Total billing pend."
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+msgid "Total cancelled quantity"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/migrations/13.0.1.11.0/post-migration.py
+++ b/stock_picking_mgmt_weight/migrations/13.0.1.11.0/post-migration.py
@@ -1,0 +1,12 @@
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE sale_order_line
+        SET pending_qty = 0.0
+        WHERE pending_qty < 0.0""",
+    )

--- a/stock_picking_mgmt_weight/models/sale_order_line.py
+++ b/stock_picking_mgmt_weight/models/sale_order_line.py
@@ -33,11 +33,13 @@ class SaleOrderLine(models.Model):
     @api.depends("product_uom_qty", "qty_delivered", "qty_cancelled")
     def _compute_pending_qty(self):
         for line in self:
-            line.pending_qty = (
-                line.product_uom_qty - line.qty_delivered - line.qty_cancelled
+            line.pending_qty = max(
+                line.product_uom_qty - line.qty_delivered - line.qty_cancelled,
+                0.0
             )
             # We only take in account positive pending quantities
-            #  (it's possible to be negative)
+            #  (legacy code, it used to be negative, so we don't use
+            #   float_is_zero)
             line.has_pending_qty = (
                 float_compare(
                     line.pending_qty,

--- a/stock_picking_mgmt_weight/views/purchase_order_line_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_line_views.xml
@@ -65,6 +65,7 @@
                 <field name="qty_received_ext" string="Received*"/>
                 <field name="pending_qty" string="Pending"/>
                 <field name="qty_classified" optional="hide"/>
+                <field name="qty_cancelled" string="Cancelled"/>
                 <field
                     name="qty_invoiced"
                     string="Billed"
@@ -81,6 +82,9 @@
                 />
                 <field name="order_incoterm_id"/>
                 <field name="order_shipping_resource_id" />
+            </xpath>
+            <xpath expr="//field[@name='product_uom']" position="attributes">
+                <attribute name="optional">hide</attribute>
             </xpath>
             <xpath expr="//field[@name='price_subtotal']" position="attributes">
                 <attribute name="sum">Total amount</attribute>

--- a/stock_picking_mgmt_weight/views/sale_order_line_views.xml
+++ b/stock_picking_mgmt_weight/views/sale_order_line_views.xml
@@ -24,6 +24,11 @@
                     name="pending_qty"
                     sum="Total pending quantity"
                 />
+                <field
+                    string="Cancelled"
+                    name="qty_cancelled"
+                    sum="Total cancelled quantity"
+                />
             </field>
         </field>
     </record>
@@ -51,6 +56,9 @@
             <field name="qty_to_invoice" position="attributes">
                 <attribute name="string">To Invoice</attribute>
                 <attribute name="sum">Total Pending Invoice Quantity</attribute>
+            </field>
+            <field name="product_uom" position="attributes">
+                <attribute name="optional">hide</attribute>
             </field>
             <xpath expr="//field[@name='price_subtotal']" position="before">
                 <field name="price_unit" />


### PR DESCRIPTION
Summary:

- Sale line: pending quantity negative becomes 0.0 // added cancelled quantity to Sale Line Menu // Hided by default UoM for Sale Line Menu
- Purchase line: added cancelled quantity to Purchase Line Menu // Hided by default UoM for Purchase Line Menu