### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: added extended invoice status to RFQ tree

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.12.0",
+    "version": "13.0.1.13.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/views/purchase_order_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_views.xml
@@ -160,6 +160,23 @@
         </field>
     </record>
 
+    <record id="purchase_order_tree" model="ir.ui.view">
+        <field name="name">purchase.order.tree (weight)</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="invoice_status" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="invoice_status" position="after">
+                <field
+                    name="invoice_status_ext"
+                    optional="show"
+                />
+            </field>
+        </field>
+    </record>
+
     <record id="purchase_order_view_tree" model="ir.ui.view">
         <field name="name">purchase.order.view.tree (weight)</field>
         <field name="model">purchase.order</field>


### PR DESCRIPTION
The new purchase order's `invoice_status_ext` column is not present in RFQ tree view. This improvement add it.

@ChristianSantamaria could you update Test environment and check it? Thanks!