### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: improved custom date propagation

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.13.0",
+    "version": "13.0.1.14.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/stock_picking.py
+++ b/stock_picking_mgmt_weight/models/stock_picking.py
@@ -134,24 +134,3 @@ class StockPicking(models.Model):
 
     def get_datetime_now(self):
         return fields.Datetime.now()
-
-    def button_validate(self):
-        """
-        When a picking comes from a classification order,
-        inherited date from purchase order is the real stock
-        reception date
-        """
-        # TODO this method shouldn't be the best solution,
-        #      action_done() maybe is better, but is multi
-        self.ensure_one()
-        stock_move_custom_date = False
-        if self.purchase_id and (
-            self.purchase_id.classification
-            or
-            self.purchase_id.propagate_custom_date
-        ):
-            stock_move_custom_date = self.scheduled_date
-        picking = self.with_context(
-            stock_move_custom_date=stock_move_custom_date
-        )
-        return super(StockPicking, picking).button_validate()


### PR DESCRIPTION
With this change, stock picking custom date propagation to their stock moves will no longer depend on "Validate" button, but to done state setting.
This will prevent corner cases that custom date shouldn't be propagated.

cc @lmiguens-solvos @ChristianSantamaria ASAP I'll update Test environment and this improvement could be properly tested