### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: enable purchase line cancel pending quants individually

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.15.0",
+    "version": "13.0.1.16.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-15 11:29+0000\n"
-"PO-Revision-Date: 2022-07-15 11:29+0000\n"
+"POT-Creation-Date: 2022-09-26 08:03+0000\n"
+"PO-Revision-Date: 2022-09-26 08:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -183,6 +183,12 @@ msgid "Cancel pending"
 msgstr "Cancelar pendiente"
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
+msgid "Cancel pending quantities for this line"
+msgstr "Cancela cantidades pendientes para esta línea"
+
+#. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__qty_cancelled
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
@@ -354,7 +360,6 @@ msgstr ""
 "asistente y verifíquelo"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Classification modification not allowed for you"
@@ -778,6 +783,11 @@ msgstr "Cámara IoT"
 #, python-format
 msgid "Iot Weight"
 msgstr "Peso UdM"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__is_cancellable
+msgid "Is Cancellable"
+msgstr "Es cancelable"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__is_default
@@ -1710,7 +1720,6 @@ msgid "Weight Selection"
 msgstr "Selección de peso"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Weight pending classification must be zero"

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-15 11:28+0000\n"
-"PO-Revision-Date: 2022-07-15 11:28+0000\n"
+"POT-Creation-Date: 2022-09-26 07:59+0000\n"
+"PO-Revision-Date: 2022-09-26 07:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -168,6 +168,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancel pending"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
+msgid "Cancel pending quantities for this line"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -334,7 +340,6 @@ msgid ""
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Classification modification not allowed for you"
@@ -747,6 +752,11 @@ msgstr ""
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #, python-format
 msgid "Iot Weight"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__is_cancellable
+msgid "Is Cancellable"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1669,7 +1679,6 @@ msgid "Weight Selection"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Weight pending classification must be zero"

--- a/stock_picking_mgmt_weight/views/purchase_order_line_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_line_views.xml
@@ -64,6 +64,14 @@
                 <field name="qty_received" string="Received" optional="hide"/>
                 <field name="qty_received_ext" string="Received*"/>
                 <field name="pending_qty" string="Pending"/>
+                <field name="is_cancellable" invisible="1"/>
+                <button
+                    name="action_cancel_pending_line"
+                    icon="fa-ban"
+                    type="object"
+                    attrs="{'invisible': [('is_cancellable', '=', False)]}"
+                    title="Cancel pending quantities for this line"
+                />
                 <field name="qty_classified" optional="hide"/>
                 <field name="qty_cancelled" string="Cancelled"/>
                 <field

--- a/stock_picking_mgmt_weight/views/purchase_order_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_views.xml
@@ -109,7 +109,15 @@
                     name="qty_cancelled"
                     string="Cancelled"
                     attrs="{'column_invisible': [('parent.cancelled_classif_count', '=', 0)]}"
-                />                
+                />
+                <field name="is_cancellable" invisible="1"/>
+                <button
+                    name="action_cancel_pending_line"
+                    icon="fa-ban"
+                    type="object"
+                    attrs="{'invisible': [('is_cancellable', '=', False)]}"
+                    title="Cancel pending quantities for this line"
+                />
                 <field name="classified" invisible="1"/>
             </xpath>
             <xpath expr="//tree/field[@name='qty_invoiced']" position="attributes">


### PR DESCRIPTION
With this improvement cancelling individual purchase line pending quantities individually becomes possible.

TODO
* Line "cancel pending" button rendering.
* Computed `is_cancellable` field performance with large databases in purchase order lines menu.

cc @ChristianSantamaria 