### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight_pot: cancel pending quantities and multi order types

### DIFF
--- a/stock_picking_mgmt_weight_pot/__manifest__.py
+++ b/stock_picking_mgmt_weight_pot/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight_pot/models/purchase_order.py
+++ b/stock_picking_mgmt_weight_pot/models/purchase_order.py
@@ -9,7 +9,11 @@ class PurchaseOrder(models.Model):
 
     def _action_cancel_pending_create(self):
         order_new = super()._action_cancel_pending_create()
-        # TODO make it safely (what happens if 0 or 2 types is returned?)
-        order_new.order_type = self.classification_order_ids.order_type
+        # TODO test "0" order types corner case
+        order_new.order_type = (
+            self.classification_order_ids
+            and self.classification_order_ids[0].order_type
+            or False
+        )
         order_new.onchange_order_type()
         return order_new


### PR DESCRIPTION
This fix prevents error when cancelling pending quantities if there are more than one order type available in current classifications. The first one is selected in that case