### PR TITLE
[13.0][IMP] stock_valuation: AVCO calc from total_quantity to stock_quantity

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.3",
+    "version": "13.0.2.0.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [


### PR DESCRIPTION
With this major change, AVCO calculation is changed:
* Standard formula for main cases is based on stock_quantity instead of total_quantity, when stock_quantity of previous date is positive.
* When stock_quantity of previous date is negative and stock_quantity of current date is negative, AVCO of previous date remains.
* When negative to positive stock_quantity occurs, new AVCO is completely the current date one.

cc @ChristianSantamaria 