### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: cancel pending quantities by line - check state condition in order

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.17.0",
+    "version": "13.0.1.17.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/purchase_order_line.py
+++ b/stock_picking_mgmt_weight/models/purchase_order_line.py
@@ -208,7 +208,7 @@ class PurchaseOrderLine(models.Model):
             # TODO float_compare, "classification_count"
             line.is_cancellable = (
                 not line.classified
-                and line.state in ["purchase", "done"]
+                and line.order_id.state in ["purchase", "done"]
                 and line.order_id.classification_count > 0
                 and line.pending_qty > 0.0
             )


### PR DESCRIPTION
Sometimes Odoo creates purchase lines in "draft" state even if the purchase is already in "done" state.

With this fix cancel pending quantities for a certain line now only depends on purchase state, so this wrong line state doesn't affect this process.

cc @ChristianSantamaria 