### PR TITLE
[13.0][FIX] stock_valuation: PHAP obtained from new sale return

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/models/stock_valuation_layer.py
+++ b/stock_valuation/models/stock_valuation_layer.py
@@ -109,9 +109,7 @@ class StockValuationLayer(models.Model):
                         #  but False is possible!!!
                         # vals["history_average_price_id"] = orig_move.get_phap_id()
                         vals["history_average_price_id"] = (
-                            move_id.sale_line_id.move_ids.filtered(
-                                lambda x: not x.origin_returned_move_id
-                            ).get_phap_id()
+                            move_id.origin_returned_move_id.stock_valuation_layer_ids.history_average_price_id.id
                         )
 
                 elif move_id.picking_type_id.code == 'outgoing':


### PR DESCRIPTION
With this fix, when a sale return comes from a sale line splitted in more than one move, an expected singleton when PHAP is calculated is avoided