### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: enable sale line cancel pending quants individually

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.17.1",
+    "version": "13.0.1.18.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-26 08:03+0000\n"
-"PO-Revision-Date: 2022-09-26 08:03+0000\n"
+"POT-Creation-Date: 2022-10-13 11:14+0000\n"
+"PO-Revision-Date: 2022-10-13 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -183,6 +183,8 @@ msgid "Cancel pending"
 msgstr "Cancelar pendiente"
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancel pending quantities for this line"
@@ -786,6 +788,7 @@ msgstr "Peso UdM"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__is_cancellable
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__is_cancellable
 msgid "Is Cancellable"
 msgstr "Es cancelable"
 

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-26 07:59+0000\n"
-"PO-Revision-Date: 2022-09-26 07:59+0000\n"
+"POT-Creation-Date: 2022-10-13 11:14+0000\n"
+"PO-Revision-Date: 2022-10-13 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -171,6 +171,8 @@ msgid "Cancel pending"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Cancel pending quantities for this line"
@@ -756,6 +758,7 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__is_cancellable
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__is_cancellable
 msgid "Is Cancellable"
 msgstr ""
 

--- a/stock_picking_mgmt_weight/views/sale_order_line_views.xml
+++ b/stock_picking_mgmt_weight/views/sale_order_line_views.xml
@@ -24,6 +24,14 @@
                     name="pending_qty"
                     sum="Total pending quantity"
                 />
+                <field name="is_cancellable" invisible="1"/>
+                <button
+                    name="action_cancel_pending_line"
+                    icon="fa-ban"
+                    type="object"
+                    attrs="{'invisible': [('is_cancellable', '=', False)]}"
+                    title="Cancel pending quantities for this line"
+                />
                 <field
                     string="Cancelled"
                     name="qty_cancelled"

--- a/stock_picking_mgmt_weight/views/sale_order_views.xml
+++ b/stock_picking_mgmt_weight/views/sale_order_views.xml
@@ -72,6 +72,14 @@
             >
                 <field name="qty_cancelled" optional="show" string="Cancelled" />
                 <field name="pending_qty" optional="hide" string="Pending" />
+                <field name="is_cancellable" invisible="1"/>
+                <button
+                    name="action_cancel_pending_line"
+                    icon="fa-ban"
+                    type="object"
+                    attrs="{'invisible': [('is_cancellable', '=', False)]}"
+                    title="Cancel pending quantities for this line"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
With this improvement, sale line pending quantity could be cancelled. Only pending stock moves are cancelled in that case.

cc @ChristianSantamaria @lmiguens-solvos 