### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: SOL cancel pending qty - do not copy qty cancelled

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.18.0",
+    "version": "13.0.1.18.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/sale_order_line.py
+++ b/stock_picking_mgmt_weight/models/sale_order_line.py
@@ -12,6 +12,7 @@ class SaleOrderLine(models.Model):
         digits="Product Unit of Measure",
         string="Cancelled Quantity",
         readonly=True,
+        copy=False,
         help="Quantities affected by 'Cancel Pending' process",
     )
     is_cancellable = fields.Boolean(compute="_compute_is_cancellable")


### PR DESCRIPTION
With this fix, when a sale order is duplicated, cancel quantities of lines aren't propagated.

cc @ChristianSantamaria 