### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: SOL undo cancel operation & better qty cancelled calculation

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.18.1",
+    "version": "13.0.1.19.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-13 11:14+0000\n"
-"PO-Revision-Date: 2022-10-13 11:14+0000\n"
+"POT-Creation-Date: 2022-10-31 09:55+0000\n"
+"PO-Revision-Date: 2022-10-31 09:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -793,6 +793,11 @@ msgid "Is Cancellable"
 msgstr "Es cancelable"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__is_decancellable
+msgid "Is Decancellable"
+msgstr "Es descancelable"
+
+#. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__is_default
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_supply_condition__is_default
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_vehicle_type__is_default
@@ -1229,6 +1234,12 @@ msgstr "Informes"
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 msgid "Repr."
 msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+msgid "Restore cancelled pending quantities for this line"
+msgstr "Restaura a pendientes las cantidades canceladas para esta línea"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-13 11:14+0000\n"
-"PO-Revision-Date: 2022-10-13 11:14+0000\n"
+"POT-Creation-Date: 2022-10-31 09:55+0000\n"
+"PO-Revision-Date: 2022-10-31 09:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -763,6 +763,11 @@ msgid "Is Cancellable"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__is_decancellable
+msgid "Is Decancellable"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__is_default
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_supply_condition__is_default
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_vehicle_type__is_default
@@ -1196,6 +1201,12 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
 msgid "Repr."
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+msgid "Restore cancelled pending quantities for this line"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/models/sale_order.py
+++ b/stock_picking_mgmt_weight/models/sale_order.py
@@ -27,7 +27,6 @@ class SaleOrder(models.Model):
         """
         Finishes selected order, cancelling pending quantities, or for a
         certain line.
-        Pending pickings are cancelled as result of this process, not vice versa
         """
         # An error is not raised due to batch action with several orders launch
         # In that case, if orders with no pending quantities are selected, this
@@ -39,9 +38,6 @@ class SaleOrder(models.Model):
             custom_line or
             self.order_line.filtered(lambda x: x.has_pending_qty)
         )
-        for line in pending_lines:
-            # TODO better get it from to-cancel pickings?
-            line.qty_cancelled += line.pending_qty
         pending_lines.move_ids.filtered(
             lambda x: x.state not in ["done", "cancel"]
         )._action_cancel()

--- a/stock_picking_mgmt_weight/views/sale_order_line_views.xml
+++ b/stock_picking_mgmt_weight/views/sale_order_line_views.xml
@@ -25,12 +25,20 @@
                     sum="Total pending quantity"
                 />
                 <field name="is_cancellable" invisible="1"/>
+                <field name="is_decancellable" invisible="1"/>
                 <button
                     name="action_cancel_pending_line"
                     icon="fa-ban"
                     type="object"
                     attrs="{'invisible': [('is_cancellable', '=', False)]}"
                     title="Cancel pending quantities for this line"
+                />
+                <button
+                    name="action_decancel_pending_line"
+                    icon="fa-eraser"
+                    type="object"
+                    attrs="{'invisible': [('is_decancellable', '=', False)]}"
+                    title="Restore cancelled pending quantities for this line"
                 />
                 <field
                     string="Cancelled"

--- a/stock_picking_mgmt_weight/views/sale_order_views.xml
+++ b/stock_picking_mgmt_weight/views/sale_order_views.xml
@@ -73,12 +73,20 @@
                 <field name="qty_cancelled" optional="show" string="Cancelled" />
                 <field name="pending_qty" optional="hide" string="Pending" />
                 <field name="is_cancellable" invisible="1"/>
+                <field name="is_decancellable" invisible="1"/>
                 <button
                     name="action_cancel_pending_line"
                     icon="fa-ban"
                     type="object"
                     attrs="{'invisible': [('is_cancellable', '=', False)]}"
                     title="Cancel pending quantities for this line"
+                />
+                <button
+                    name="action_decancel_pending_line"
+                    icon="fa-eraser"
+                    type="object"
+                    attrs="{'invisible': [('is_decancellable', '=', False)]}"
+                    title="Restore cancelled pending quantities for this line"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
With this PR two improvements are achieved:

- "Undo cancel" operation by line is now supported for sale lines.
- Cancelled quantity is now linked to cancelled quantities in related stock moves for each sale line.
- When undo cancel operation is selected, current cancelled stock move is deleted and a new stock move (and stock picking when needed) is created.

The undo cancel operation, when available, is shown with this icon:

![imagen](https://user-images.githubusercontent.com/12749832/198997462-f9f75057-988f-4f48-8d05-fe4fca77db0d.png)


cc @lmiguens-solvos @ChristianSantamaria 