### PR TITLE
[13.0] [FIX] stock_valuation: PHAP obtained from new purchase return

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.0.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/models/stock_valuation_layer.py
+++ b/stock_valuation/models/stock_valuation_layer.py
@@ -131,9 +131,7 @@ class StockValuationLayer(models.Model):
                         #  but False is possible!!!
                         # vals["history_average_price_id"] = orig_move.get_phap_id()
                         vals["history_average_price_id"] = (
-                            move_id.purchase_line_id.move_ids.filtered(
-                                lambda x: not x.origin_returned_move_id
-                            ).get_phap_id()
+                            move_id.origin_returned_move_id.stock_valuation_layer_ids.history_average_price_id.id
                         )
 
                 elif move_id.picking_type_id.code == 'internal':


### PR DESCRIPTION
With this fix, when a purchase return comes from a purchase line splitted in more than one move, an expected singleton when PHAP is calculated is avoided.

This is the same fix as #54 for purchase operations