### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: ensure no cancelled moves when SO confirmation

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.19.0",
+    "version": "13.0.1.19.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [
@@ -38,6 +38,7 @@
         "views/stock_move_views.xml",
         "wizards/move_line_weight_views.xml",
         "wizards/move_weight_views.xml",
+        "wizards/sale_order_confirm_views.xml",
         "views/stock_picking_type.xml",
         "views/stock_picking_views.xml",
         "views/res_partner_views.xml",

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 09:55+0000\n"
-"PO-Revision-Date: 2022-10-31 09:55+0000\n"
+"POT-Creation-Date: 2022-12-13 12:33+0000\n"
+"PO-Revision-Date: 2022-12-13 12:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -51,6 +51,22 @@ msgstr ""
 #, python-format
 msgid "/weight_images/%s"
 msgstr "/imagenes_pesadas/%s"
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_sale_order_confirm_wizard_form
+msgid ""
+"<span name=\"warn_message\">\n"
+"                            Cancelled quantities will be set to 0. Once\n"
+"                            confirmed, please review then if cancel pending\n"
+"                            quantities should to be set again\n"
+"                        </span>"
+msgstr ""
+"<span name=\"warn_message\">\n"
+"                            Al confirmar el pedido se borrarán todas las cantidades\n"
+"                            canceladas existentes actualmente, revise si alguna de ellas\n"
+"                            era de restos y debe seguir cancelada una vez confirmado el pedido.\n"
+"                            Si es así, deben ser canceladas de nuevo después de confirmar el pedido\n"
+"                        </span>"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.label_transfer_template_view_pdf
@@ -165,6 +181,7 @@ msgid "Cameras for Scale"
 msgstr "Cámaras para báscula"
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_sale_order_confirm_wizard_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_move_line_form_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_move_weight_wizard_form_weight
 msgid "Cancel"
@@ -435,6 +452,11 @@ msgid "Configuration"
 msgstr "Configuración"
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_sale_order_confirm_wizard_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_res_partner
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__partner_id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__partner_id
@@ -480,6 +502,7 @@ msgid "Container Vgm Weight"
 msgstr "Peso VGM del contenedor"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__create_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__create_uid
@@ -490,6 +513,7 @@ msgid "Created by"
 msgstr "Creado por"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__create_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__create_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__create_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__create_date
@@ -558,6 +582,7 @@ msgid "Dest. weight"
 msgstr "En báscula"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__display_name
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__display_name
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__display_name
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__display_name
@@ -660,6 +685,7 @@ msgid "Historical"
 msgstr "Histórico"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__id
@@ -817,6 +843,7 @@ msgid "It is necessary to assign a vehicle to perform this operation."
 msgstr "Es necesario asignar un vehículo para realizar esta operación."
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard____last_update
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource____last_update
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard____last_update
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard____last_update
@@ -832,6 +859,7 @@ msgid "Last Towing"
 msgstr "Último remolque"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__write_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__write_uid
@@ -842,6 +870,7 @@ msgid "Last Updated by"
 msgstr "Última actualización de"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__write_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__write_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__write_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__write_date
@@ -986,6 +1015,11 @@ msgstr "Operaciones"
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_picking__operator_id
 msgid "Operator"
 msgstr "Operador"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__order_id
+msgid "Order"
+msgstr "Pedido"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__order_line_id
@@ -1245,6 +1279,11 @@ msgstr "Restaura a pendientes las cantidades canceladas para esta línea"
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit
 msgid "Safety"
 msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model,name:stock_picking_mgmt_weight.model_sale_order_confirm_wizard
+msgid "Sale Order Confirm Wizard"
+msgstr "Asistente de confirmación de pedido de venta"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_sale_order
@@ -1698,6 +1737,12 @@ msgstr "Clasif. pdte. facturar"
 #: model:ir.model,name:stock_picking_mgmt_weight.model_stock_warehouse
 msgid "Warehouse"
 msgstr "Almacén"
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/sale_order.py:0
+#, python-format
+msgid "Warning"
+msgstr "Aviso"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.stock_move_mgmt_weight_frontend_weight_form_view

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 09:55+0000\n"
-"PO-Revision-Date: 2022-10-31 09:55+0000\n"
+"POT-Creation-Date: 2022-12-13 12:32+0000\n"
+"PO-Revision-Date: 2022-12-13 12:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -40,6 +40,16 @@ msgstr ""
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "/weight_images/%s"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_sale_order_confirm_wizard_form
+msgid ""
+"<span name=\"warn_message\">\n"
+"                            Cancelled quantities will be set to 0. Once\n"
+"                            confirmed, please review then if cancel pending\n"
+"                            quantities should to be set again\n"
+"                        </span>"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -153,6 +163,7 @@ msgid "Cameras for Scale"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_sale_order_confirm_wizard_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_move_line_form_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_move_weight_wizard_form_weight
 msgid "Cancel"
@@ -415,6 +426,11 @@ msgid "Configuration"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_sale_order_confirm_wizard_form
+msgid "Confirm"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_res_partner
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__partner_id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__partner_id
@@ -460,6 +476,7 @@ msgid "Container Vgm Weight"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__create_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__create_uid
@@ -470,6 +487,7 @@ msgid "Created by"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__create_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__create_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__create_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__create_date
@@ -536,6 +554,7 @@ msgid "Dest. weight"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__display_name
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__display_name
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__display_name
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__display_name
@@ -632,6 +651,7 @@ msgid "Historical"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__id
@@ -787,6 +807,7 @@ msgid "It is necessary to assign a vehicle to perform this operation."
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard____last_update
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource____last_update
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard____last_update
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard____last_update
@@ -802,6 +823,7 @@ msgid "Last Towing"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__write_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__write_uid
@@ -812,6 +834,7 @@ msgid "Last Updated by"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__write_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_shipping_resource__write_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__write_date
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__write_date
@@ -955,6 +978,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_picking__operator_id
 msgid "Operator"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_confirm_wizard__order_id
+msgid "Order"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1212,6 +1240,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit
 msgid "Safety"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model,name:stock_picking_mgmt_weight.model_sale_order_confirm_wizard
+msgid "Sale Order Confirm Wizard"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1656,6 +1689,12 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_stock_warehouse
 msgid "Warehouse"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/sale_order.py:0
+#, python-format
+msgid "Warning"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/models/sale_order_line.py
+++ b/stock_picking_mgmt_weight/models/sale_order_line.py
@@ -86,6 +86,16 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         if not self.is_decancellable:
             return
-        sm_cancelled = self.move_ids.filtered(lambda x: x.state == "cancel")
-        sm_cancelled.sudo().unlink()
+        self._unlink_cancelled_moves()
         self._action_launch_stock_rule()
+
+    def _unlink_cancelled_moves(self, unlink=True):
+        sm_cancelled = self.mapped("move_ids").filtered(
+            lambda x: x.state == "cancel"
+        )
+        if sm_cancelled:
+            if unlink:
+                sm_cancelled.sudo().unlink()
+            return True
+        else:
+            return False

--- a/stock_picking_mgmt_weight/wizards/__init__.py
+++ b/stock_picking_mgmt_weight/wizards/__init__.py
@@ -1,2 +1,3 @@
 from . import move_weight
 from . import move_line_weight
+from . import sale_order_confirm

--- a/stock_picking_mgmt_weight/wizards/sale_order_confirm.py
+++ b/stock_picking_mgmt_weight/wizards/sale_order_confirm.py
@@ -1,0 +1,17 @@
+# © 2021 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3 - See https://www.gnu.org/licenses/lgpl-3.0.html
+
+from odoo import fields, models
+
+
+class SaleOrderConfirmWizard(models.TransientModel):
+    _name = "sale.order.confirm.wizard"
+    _description = "Sale Order Confirm Wizard"
+
+    order_id = fields.Many2one("sale.order", readonly=True)
+
+    def action_confirm(self):
+        self.ensure_one()
+        self.order_id.with_context(
+            skip_confirm_cancel_moves=True
+        ).action_confirm()

--- a/stock_picking_mgmt_weight/wizards/sale_order_confirm_views.xml
+++ b/stock_picking_mgmt_weight/wizards/sale_order_confirm_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sale_order_confirm_wizard_form" model="ir.ui.view">
+        <field name="name">sale.order.confirm.wizard form</field>
+        <field name="model">sale.order.confirm.wizard</field>
+        <field name="arch" type="xml"> 
+            <form>
+                <sheet>
+                    <group>
+                        <span name="warn_message">
+                            Cancelled quantities will be set to 0. Once
+                            confirmed, please review then if cancel pending
+                            quantities should to be set again
+                        </span>
+                    </group>
+                    <footer>
+                        <button
+                            name="action_confirm"
+                            string="Confirm"
+                            type="object"
+                            class="oe_highlight"
+                        />
+                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
For proper cancel and pending quantities calculation, a SO should only have cancelled stock moves that belong to cancel pending quantities operation. With this fix, when a SO is confirmed, every cancelled move is erased to ensure no previous cancelled moves exist, that would break pending and cancelled quantities calculation.

With this fix, when a SO is cancelled, and later confirmed again, previous cancelled quantities by line are lost and they should be individually cancelled again.

@lmiguens-solvos already installed in Test environment, could you test it? Thanks!