### PR TITLE
[13.0][IMP] stock_valuation: enable history average price & quantity edition

### DIFF
--- a/stock_valuation/__init__.py
+++ b/stock_valuation/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import report
+from . import wizards

--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.1",
+    "version": "13.0.3.0.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [
@@ -24,6 +24,7 @@
         "views/product_history_average_price_views.xml",
         "views/product_average_price_views.xml",
         "views/product_product_views.xml",
+        "wizards/phap_price_edit_views.xml",
         "report/product_average_price_date_views.xml",
         "report/product_average_price_date_wizard_views.xml",
     ],

--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -25,6 +25,7 @@
         "views/product_average_price_views.xml",
         "views/product_product_views.xml",
         "wizards/phap_price_edit_views.xml",
+        "wizards/phap_qty_edit_views.xml",
         "report/product_average_price_date_views.xml",
         "report/product_average_price_date_wizard_views.xml",
     ],

--- a/stock_valuation/i18n/es.po
+++ b/stock_valuation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-30 18:39+0000\n"
-"PO-Revision-Date: 2023-01-30 18:39+0000\n"
+"POT-Creation-Date: 2023-02-03 12:04+0000\n"
+"PO-Revision-Date: 2023-02-03 12:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -112,6 +112,7 @@ msgstr "Precio medio durante la creación"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -122,8 +123,22 @@ msgstr "Cambiar precio medio"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Change stock quantity"
+msgstr "Cambiar la cantidad en stock"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
 msgid "Changed by"
 msgstr "Cambiado por"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
+msgid ""
+"Changing quantity will fire later stock valuation recalculation.\n"
+"                            This process could take unexpected time execution."
+msgstr ""
+"Cambiar la cantidad lanzará recálculos de cantidad en stock posteriores.\n"
+"                            Este proceso podría llevar un tiempo indeterminado."
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__company_id
@@ -134,6 +149,7 @@ msgstr "Empresa"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -144,6 +160,7 @@ msgstr "Fecha de creación de la valoración"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_uid
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_uid
@@ -153,6 +170,7 @@ msgstr "Creado por"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_date
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_date
@@ -174,6 +192,11 @@ msgid "Current average price"
 msgstr "Precio medio actual"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__stock_quantity
+msgid "Current stock quantity"
+msgstr "Cantidad en stock actual"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__date
@@ -188,6 +211,7 @@ msgstr "Evolución por fecha"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__display_name
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__display_name
@@ -252,6 +276,7 @@ msgstr "Precios medios históricos"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__id
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__id
@@ -288,6 +313,7 @@ msgstr "Es una devolución"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard____last_update
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard____last_update
@@ -297,6 +323,7 @@ msgstr "Últ. modificado en"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_uid
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_uid
@@ -306,6 +333,7 @@ msgstr "Últ. actualización por"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_date
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_date
@@ -316,7 +344,7 @@ msgstr "Últ. actualización en"
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
 msgid "Last manually changed on"
-msgstr "Cambiado manualmente por últ. vez en"
+msgstr "Cambiado manualmente por ult. vez en"
 
 #. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
@@ -324,9 +352,24 @@ msgid "Leave empty if every warehouse is required"
 msgstr "Dejar vacío si se solicitan todos los almacenes"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__location_id
+msgid "Location Stock"
+msgstr "Ubicación de stock"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_main_attachment_id
 msgid "Main Attachment"
 msgstr "Adjunto principal"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
+msgid ""
+"Making this action will add/remove to selected location the stock\n"
+"                            quantity as a result of the difference between current and desired\n"
+"                            quantity"
+msgstr ""
+"Realizar esta acción añadirá o restará a la ubicación seleccionada la cantidad\n"
+"                            como resultado de la diferencia entre la cantidad actual y la deseada"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
@@ -353,6 +396,11 @@ msgstr "Mensajes"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_edit
 msgid "New average price"
 msgstr "Nuevo precio medio"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__stock_quantity_new
+msgid "New stock quantity"
+msgstr "Nueva cantidad en stock"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction_counter
@@ -385,7 +433,13 @@ msgid "PHAP Price Edit Wizard"
 msgstr "Asistente de edición de precio de PHAP"
 
 #. module: stock_valuation
+#: model:ir.model,name:stock_valuation.model_phap_qty_edit_wizard
+msgid "PHAP Quantity Edit Wizard"
+msgstr "Asistente de edición de cantidad en stock"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__phap_id
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__phap_id
 msgid "Phap"
 msgstr "PHAP"
 
@@ -464,6 +518,12 @@ msgid "Purchase Order Line"
 msgstr "Línea de pedido de compra"
 
 #. module: stock_valuation
+#: code:addons/stock_valuation/models/product_history_average_price.py:0
+#, python-format
+msgid "Quantity Edit Wizard"
+msgstr "Asistente de edición de cantidad"
+
+#. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_stock_quant
 msgid "Quants"
 msgstr "Cantidades"
@@ -531,6 +591,7 @@ msgid "Stock Valuation Layer"
 msgstr "Capa de valoración de stock"
 
 #. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_phap_qty_edit_wizard__stock_quantity
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__stock_quantity
 msgid "Stock for this product and warehouse at this date"
 msgstr "Existencias para este producto y almacén a esta fecha"

--- a/stock_valuation/i18n/es.po
+++ b/stock_valuation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-23 15:53+0000\n"
-"PO-Revision-Date: 2022-08-23 15:53+0000\n"
+"POT-Creation-Date: 2023-01-30 18:39+0000\n"
+"PO-Revision-Date: 2023-01-30 18:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,9 +33,32 @@ msgid "<span class=\"o_stat_text\">View graph</span>"
 msgstr "<span class=\"o_stat_text\">Ver gráfico</span>"
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+msgid ""
+"<span name=\"warn_message\">\n"
+"                            Changing price will fire later prices recalculation.\n"
+"                            This process could take unexpected time execution.\n"
+"                        </span>"
+msgstr ""
+"<span name=\"warn_message\">\n"
+"                            Cambiar el precio lanzará recálculos de precios posteriores.\n"
+"                            Este proceso podría llevar un tiempo indeterminado.\n"
+"                        </span>"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__accumulated
 msgid "Accumulated"
 msgstr "Acumulado"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction
+msgid "Action Needed"
+msgstr "Acción necesaria"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_attachment_count
+msgid "Attachment Count"
+msgstr "Nº de adjuntos"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__average_price
@@ -45,11 +68,39 @@ msgid "Average Price"
 msgstr "Precio medio"
 
 #. module: stock_valuation
+#: code:addons/stock_valuation/models/product_history_average_price.py:0
+#, python-format
+msgid "Average Price Edit Wizard"
+msgstr "Asistente de edición de precio medio"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_manual
+msgid "Average Price Manual"
+msgstr "Precio medio manual"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_manual_dt
+msgid "Average Price Manual Dt"
+msgstr "Fecha de precio medio manual"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_manual_user
+msgid "Average Price Manual User"
+msgstr "Usuario de precio medio manual"
+
+#. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_average_price_date_wizard_form
 msgid "Average price at date Wizard"
 msgstr "Asistente del precio medio a un día"
 
 #. module: stock_valuation
+#: code:addons/stock_valuation/models/product_history_average_price.py:0
+#, python-format
+msgid "Average price cannot be negative!"
+msgstr "¡El precio medio no puede ser negativo!"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_phap_price_edit_wizard__average_price
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price
 msgid "Average price for this product and warehouse at this date"
 msgstr "Precio medio para este producto y almacén a esta fecha"
@@ -60,6 +111,21 @@ msgid "Average price on creation"
 msgstr "Precio medio durante la creación"
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form_edit
+msgid "Change average price"
+msgstr "Cambiar precio medio"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Changed by"
+msgstr "Cambiado por"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__company_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__company_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__company_id
@@ -67,11 +133,17 @@ msgid "Company"
 msgstr "Empresa"
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__create_date_valuation
 msgid "Create Date Valuation"
 msgstr "Fecha de creación de la valoración"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_uid
@@ -80,6 +152,7 @@ msgid "Created by"
 msgstr "Creado por"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_date
@@ -88,11 +161,17 @@ msgid "Created on"
 msgstr "Creado en"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__currency_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__currency_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__currency_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__currency_id
 msgid "Currency"
 msgstr "Moneda"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__average_price
+msgid "Current average price"
+msgstr "Precio medio actual"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__date
@@ -108,6 +187,7 @@ msgid "Date evolution"
 msgstr "Evolución por fecha"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__display_name
@@ -119,6 +199,21 @@ msgstr "Nombre a mostrar"
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__document_origin
 msgid "Document Origin"
 msgstr "Doc. origen"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_follower_ids
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_channel_ids
+msgid "Followers (Channels)"
+msgstr "Seguidores (canales)"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_partner_ids
+msgid "Followers (Partners)"
+msgstr "Seguidores (contactos)"
 
 #. module: stock_valuation
 #: code:addons/stock_valuation/models/stock_move_line.py:0
@@ -156,6 +251,7 @@ msgid "History Average Prices"
 msgstr "Precios medios históricos"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__id
@@ -164,11 +260,34 @@ msgid "ID"
 msgstr "Id."
 
 #. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_needaction
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_unread
+msgid "If checked, new messages require your attention."
+msgstr "Cuando está marcado, mensajes nuevos requieren su atención"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_has_error
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr "Cuando está marcado, algunos mensajes tienen error de envío"
+
+#. module: stock_valuation
+#: model:res.groups,name:stock_valuation.group_stock_history_average_price_edit
+msgid "Inventory: can edit history average price"
+msgstr "Inventario: puede editar el precio medio histórico"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_is_follower
+msgid "Is Follower"
+msgstr "Es seguidor"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__is_return
 msgid "Is Return"
 msgstr "Es una devolución"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard____last_update
@@ -177,6 +296,7 @@ msgid "Last Modified on"
 msgstr "Últ. modificado en"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_uid
@@ -185,6 +305,7 @@ msgid "Last Updated by"
 msgstr "Últ. actualización por"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_date
@@ -193,9 +314,80 @@ msgid "Last Updated on"
 msgstr "Últ. actualización en"
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Last manually changed on"
+msgstr "Cambiado manualmente por últ. vez en"
+
+#. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
 msgid "Leave empty if every warehouse is required"
 msgstr "Dejar vacío si se solicitan todos los almacenes"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_main_attachment_id
+msgid "Main Attachment"
+msgstr "Adjunto principal"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Manual info"
+msgstr "Información manual"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_search
+msgid "Manually set"
+msgstr "Establecido manualmente"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_error
+msgid "Message Delivery error"
+msgstr "Error de envío de mensaje"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_ids
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__average_price_new
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_edit
+msgid "New average price"
+msgstr "Nuevo precio medio"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction_counter
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_error_counter
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de envío"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_unread_counter
+msgid "Number of unread messages"
+msgstr "Número de mensajes sin leer"
+
+#. module: stock_valuation
+#: model:ir.model,name:stock_valuation.model_phap_price_edit_wizard
+msgid "PHAP Price Edit Wizard"
+msgstr "Asistente de edición de precio de PHAP"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__phap_id
+msgid "Phap"
+msgstr "PHAP"
 
 #. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_product_product
@@ -282,6 +474,11 @@ msgid "Reference"
 msgstr "Referencia"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr "Error de envío de SMS"
+
+#. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_average_price_date_wizard_form
 msgid "Search"
 msgstr "Buscar"
@@ -290,6 +487,11 @@ msgstr "Buscar"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
 msgid "Selected warehouses"
 msgstr "Almacenes seleccionados"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual
+msgid "Shows if last average price was manually set"
+msgstr "Muestra si el último precio medio fue establecido manualmente"
 
 #. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__total_quantity_day
@@ -309,7 +511,7 @@ msgstr "Precios medios por almacén"
 #. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de existencias"
+msgstr "Movimiento de Inventario"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__stock_quantity
@@ -355,6 +557,11 @@ msgid "Techical field for Total Inputs valuation"
 msgstr "Campo técnico para disponer del valor total acumulado en entradas"
 
 #. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_edit
+msgid "Technical field that allow us to edit averagre price"
+msgstr "Campo técnico que nos permite editar el precio medio"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__total_quantity
 msgid "Total accum. inputs"
 msgstr "Total acum. en entradas"
@@ -363,6 +570,16 @@ msgstr "Total acum. en entradas"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__total_quantity_day
 msgid "Total inputs"
 msgstr "Total entradas"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread
+msgid "Unread Messages"
+msgstr "Mensajes no leídos"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr "Contador de mensajes no leídos"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_form_inherit
@@ -393,3 +610,26 @@ msgstr "Valoraciones"
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_search_inherit
 msgid "Warehouse"
 msgstr "Almacén"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__website_message_ids
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__website_message_ids
+msgid "Website communication history"
+msgstr "Historial de comunicación del website"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual_dt
+msgid "When price was manually set, shows the change date"
+msgstr ""
+"Cuando el precio fue establecido manualmente, muestra la fecha de cambio"
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual_user
+msgid "When price was manually set, shows the user that made this change"
+msgstr ""
+"Cuando el precio fue establecido manualmente, muestra el usuario que realizó"
+" el cambio"

--- a/stock_valuation/i18n/stock_valuation.pot
+++ b/stock_valuation/i18n/stock_valuation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-23 15:51+0000\n"
-"PO-Revision-Date: 2022-08-23 15:51+0000\n"
+"POT-Creation-Date: 2023-01-30 18:37+0000\n"
+"PO-Revision-Date: 2023-01-30 18:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,8 +33,27 @@ msgid "<span class=\"o_stat_text\">View graph</span>"
 msgstr ""
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+msgid ""
+"<span name=\"warn_message\">\n"
+"                            Changing price will fire later prices recalculation.\n"
+"                            This process could take unexpected time execution.\n"
+"                        </span>"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__accumulated
 msgid "Accumulated"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_attachment_count
+msgid "Attachment Count"
 msgstr ""
 
 #. module: stock_valuation
@@ -45,11 +64,39 @@ msgid "Average Price"
 msgstr ""
 
 #. module: stock_valuation
+#: code:addons/stock_valuation/models/product_history_average_price.py:0
+#, python-format
+msgid "Average Price Edit Wizard"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_manual
+msgid "Average Price Manual"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_manual_dt
+msgid "Average Price Manual Dt"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_manual_user
+msgid "Average Price Manual User"
+msgstr ""
+
+#. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_average_price_date_wizard_form
 msgid "Average price at date Wizard"
 msgstr ""
 
 #. module: stock_valuation
+#: code:addons/stock_valuation/models/product_history_average_price.py:0
+#, python-format
+msgid "Average price cannot be negative!"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_phap_price_edit_wizard__average_price
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price
 msgid "Average price for this product and warehouse at this date"
 msgstr ""
@@ -60,10 +107,30 @@ msgid "Average price on creation"
 msgstr ""
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form_edit
+msgid "Change average price"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Changed by"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__company_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__company_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__company_id
 msgid "Company"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+msgid "Confirm"
 msgstr ""
 
 #. module: stock_valuation
@@ -72,6 +139,7 @@ msgid "Create Date Valuation"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_uid
@@ -80,6 +148,7 @@ msgid "Created by"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_date
@@ -88,10 +157,16 @@ msgid "Created on"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__currency_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__currency_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__currency_id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__currency_id
 msgid "Currency"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__average_price
+msgid "Current average price"
 msgstr ""
 
 #. module: stock_valuation
@@ -108,6 +183,7 @@ msgid "Date evolution"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__display_name
@@ -118,6 +194,21 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__document_origin
 msgid "Document Origin"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_channel_ids
+msgid "Followers (Channels)"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_partner_ids
+msgid "Followers (Partners)"
 msgstr ""
 
 #. module: stock_valuation
@@ -153,6 +244,7 @@ msgid "History Average Prices"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__id
@@ -161,11 +253,34 @@ msgid "ID"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_needaction
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_unread
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_has_error
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: stock_valuation
+#: model:res.groups,name:stock_valuation.group_stock_history_average_price_edit
+msgid "Inventory: can edit history average price"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__is_return
 msgid "Is Return"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard____last_update
@@ -174,6 +289,7 @@ msgid "Last Modified on"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_uid
@@ -182,6 +298,7 @@ msgid "Last Updated by"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_date
@@ -190,8 +307,79 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Last manually changed on"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
 msgid "Leave empty if every warehouse is required"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Manual info"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_search
+msgid "Manually set"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__average_price_new
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_edit
+msgid "New average price"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__message_unread_counter
+msgid "Number of unread messages"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model,name:stock_valuation.model_phap_price_edit_wizard
+msgid "PHAP Price Edit Wizard"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__phap_id
+msgid "Phap"
 msgstr ""
 
 #. module: stock_valuation
@@ -279,6 +467,11 @@ msgid "Reference"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_average_price_date_wizard_form
 msgid "Search"
 msgstr ""
@@ -286,6 +479,11 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
 msgid "Selected warehouses"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual
+msgid "Shows if last average price was manually set"
 msgstr ""
 
 #. module: stock_valuation
@@ -349,6 +547,11 @@ msgid "Techical field for Total Inputs valuation"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_edit
+msgid "Technical field that allow us to edit averagre price"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__total_quantity
 msgid "Total accum. inputs"
 msgstr ""
@@ -356,6 +559,16 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__total_quantity_day
 msgid "Total inputs"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread
+msgid "Unread Messages"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread_counter
+msgid "Unread Messages Counter"
 msgstr ""
 
 #. module: stock_valuation
@@ -386,4 +599,24 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_price_date_search
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_search_inherit
 msgid "Warehouse"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual_dt
+msgid "When price was manually set, shows the change date"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual_user
+msgid "When price was manually set, shows the user that made this change"
 msgstr ""

--- a/stock_valuation/i18n/stock_valuation.pot
+++ b/stock_valuation/i18n/stock_valuation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-30 18:37+0000\n"
-"PO-Revision-Date: 2023-01-30 18:37+0000\n"
+"POT-Creation-Date: 2023-02-03 12:04+0000\n"
+"PO-Revision-Date: 2023-02-03 12:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -108,6 +108,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
 msgid "Cancel"
 msgstr ""
 
@@ -118,7 +119,19 @@ msgstr ""
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
+msgid "Change stock quantity"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form
 msgid "Changed by"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
+msgid ""
+"Changing quantity will fire later stock valuation recalculation.\n"
+"                            This process could take unexpected time execution."
 msgstr ""
 
 #. module: stock_valuation
@@ -130,6 +143,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
 msgid "Confirm"
 msgstr ""
 
@@ -140,6 +154,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_uid
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_uid
@@ -149,6 +164,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__create_date
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__create_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__create_date
@@ -170,6 +186,11 @@ msgid "Current average price"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__stock_quantity
+msgid "Current stock quantity"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__date
@@ -184,6 +205,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__display_name
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__display_name
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__display_name
@@ -245,6 +267,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__id
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__id
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__id
@@ -281,6 +304,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard____last_update
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date____last_update
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard____last_update
@@ -290,6 +314,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_uid
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_uid
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_uid
@@ -299,6 +324,7 @@ msgstr ""
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__write_date
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__write_date
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__write_date
@@ -317,8 +343,21 @@ msgid "Leave empty if every warehouse is required"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__location_id
+msgid "Location Stock"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_main_attachment_id
 msgid "Main Attachment"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
+msgid ""
+"Making this action will add/remove to selected location the stock\n"
+"                            quantity as a result of the difference between current and desired\n"
+"                            quantity"
 msgstr ""
 
 #. module: stock_valuation
@@ -345,6 +384,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__average_price_new
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__average_price_edit
 msgid "New average price"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__stock_quantity_new
+msgid "New stock quantity"
 msgstr ""
 
 #. module: stock_valuation
@@ -378,7 +422,13 @@ msgid "PHAP Price Edit Wizard"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model,name:stock_valuation.model_phap_qty_edit_wizard
+msgid "PHAP Quantity Edit Wizard"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__phap_id
+#: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__phap_id
 msgid "Phap"
 msgstr ""
 
@@ -457,6 +507,12 @@ msgid "Purchase Order Line"
 msgstr ""
 
 #. module: stock_valuation
+#: code:addons/stock_valuation/models/product_history_average_price.py:0
+#, python-format
+msgid "Quantity Edit Wizard"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_stock_quant
 msgid "Quants"
 msgstr ""
@@ -522,6 +578,7 @@ msgid "Stock Valuation Layer"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_phap_qty_edit_wizard__stock_quantity
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__stock_quantity
 msgid "Stock for this product and warehouse at this date"
 msgstr ""

--- a/stock_valuation/models/stock_move.py
+++ b/stock_valuation/models/stock_move.py
@@ -152,7 +152,7 @@ class StockMove(models.Model):
 
         return done_moves
 
-    def _compute_phaps_and_update_slvs(self, phaps=False):
+    def _compute_phaps_and_update_slvs(self, phaps=False, phap_omit=False):
         phaps_processed = self.env["product.history.average.price"]
         """
         For a set of moves, makes a complete cycle
@@ -187,7 +187,12 @@ class StockMove(models.Model):
                 ('warehouse_id', 'in', warehouses),
                 ('date', '>=', oldest_phap.date),
             ])
-            later_phaps._compute_average_price()
+            compute_phaps = later_phaps
+            # Omit PHAP that fired this computation in case of manual price,
+            #  that we cannot recompute
+            if phap_omit:
+                compute_phaps -= phap_omit
+            compute_phaps._compute_average_price()
             # Average prices have changed for some dates, dependent
             #  valuations must change too (e.g. sale moves, internal moves)
             # In the case of internal moves, new PHAP changes should be

--- a/stock_valuation/models/stock_valuation_layer.py
+++ b/stock_valuation/models/stock_valuation_layer.py
@@ -147,7 +147,8 @@ class StockValuationLayer(models.Model):
                         move_id.product_id,
                         self.env["stock.warehouse"].browse(
                             vals["warehouse_id"]
-                        )
+                        ),
+                        dt=date
                     )
                     vals["value"] = vals.get("unit_cost") * vals.get("quantity")
 

--- a/stock_valuation/security/stock_valuation_security.xml
+++ b/stock_valuation/security/stock_valuation_security.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="group_stock_history_average_price_edit" model="res.groups">
+        <field name="name">Inventory: can edit history average price</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field
+            name="implied_ids"
+            eval="[(4, ref('stock.group_stock_manager'))]"
+        />
+    </record>
+    
     <record model="ir.rule" id="product_average_price_comp_rule">
         <field name="name">Product Average Price multi-company</field>
         <field name="model_id" ref="model_product_average_price" />

--- a/stock_valuation/views/product_history_average_price_views.xml
+++ b/stock_valuation/views/product_history_average_price_views.xml
@@ -75,6 +75,12 @@
         <field name="arch" type="xml">
             <form>
                 <header>
+                    <button
+                        name="button_qty_edit"
+                        type="object"
+                        string="Change stock quantity"
+                        icon="fa-pencil"
+                    />
                 </header>
                 <sheet>
                     <group>

--- a/stock_valuation/views/product_history_average_price_views.xml
+++ b/stock_valuation/views/product_history_average_price_views.xml
@@ -38,6 +38,12 @@
                     date="date"
                     default_period="this_month"
                 />
+                <separator />
+                <filter
+                    name="filter_manual"
+                    string="Manually set"
+                    domain="[('average_price_manual', '=', True)]"
+                />
                 <group expand="0" string="Group By">
                     <filter
                         string="Product"
@@ -68,6 +74,8 @@
         <field name="model">product.history.average.price</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                </header>
                 <sheet>
                     <group>
                         <group>
@@ -94,8 +102,29 @@
                         <page string="Valuations">
                             <field name="svl_ids" />
                         </page>
+                        <page string="Manual info">
+                            <group>
+                                <field
+                                    name="average_price_manual"
+                                    widget="boolean_toggle"
+                                />
+                                <field
+                                    name="average_price_manual_dt"
+                                    string="Last manually changed on"
+                                    attrs="{'invisible': [('average_price_manual', '=', False)]}"
+                                />
+                                <field
+                                    name="average_price_manual_user"
+                                    string="Changed by"
+                                    attrs="{'invisible': [('average_price_manual', '=', False)]}"
+                                />
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>                
             </form>
         </field>
     </record>
@@ -122,13 +151,40 @@
             </field>
         </field>
     </record>
+    <record id="view_product_history_average_price_form_edit" model="ir.ui.view">
+        <field name="name">product.history.average.price form price edit</field>
+        <field name="model">product.history.average.price</field>
+        <field
+            name="inherit_id"
+            ref="stock_valuation.view_product_history_average_price_form"
+        />
+        <field
+            name="groups_id"
+            eval="[(4, ref('stock_valuation.group_stock_history_average_price_edit'))]"
+        />
+        <field name="arch" type="xml">
+            <header position="inside">
+                <button
+                    name="button_price_edit"
+                    type="object"
+                    string="Change average price"
+                    icon="fa-dollar"
+                />
+            </header>
+        </field>
+    </record>
 
     <record id="view_product_history_average_price_tree" model="ir.ui.view">
         <field name="name">product.history.average.price tree</field>
         <field name="model">product.history.average.price</field>
         <field name="arch" type="xml">
-            <tree default_order="date desc">
+            <tree
+                default_order="date desc"
+                decoration-bf="average_price_manual == True"
+                decoration-danger="average_price_manual == True"
+            >
                 <field name="currency_id" invisible="1" />
+                <field name="average_price_manual" invisible="1" />
                 <field name="date" />
                 <field name="product_id" />
                 <field

--- a/stock_valuation/wizards/__init__.py
+++ b/stock_valuation/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import phap_price_edit
+from . import phap_qty_edit

--- a/stock_valuation/wizards/__init__.py
+++ b/stock_valuation/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import phap_price_edit

--- a/stock_valuation/wizards/phap_price_edit.py
+++ b/stock_valuation/wizards/phap_price_edit.py
@@ -1,0 +1,21 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3 - See https://www.gnu.org/licenses/lgpl-3.0.html
+
+from odoo import fields, models
+
+
+class PhapPriceEditWizard(models.TransientModel):
+    _name = "phap.price.edit.wizard"
+    _description = "PHAP Price Edit Wizard"
+
+    phap_id = fields.Many2one("product.history.average.price", readonly=True)
+    currency_id = fields.Many2one(related="phap_id.currency_id")
+    average_price = fields.Monetary(
+        related="phap_id.average_price",
+        string="Current average price",
+    )
+    average_price_new = fields.Monetary(string="New average price")
+
+    def action_confirm(self):
+        self.ensure_one()
+        self.phap_id.sudo().average_price_edit = self.average_price_new

--- a/stock_valuation/wizards/phap_price_edit_views.xml
+++ b/stock_valuation/wizards/phap_price_edit_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_phap_price_edit_wizard_form" model="ir.ui.view">
+        <field name="name">phap.price.edit.wizard form</field>
+        <field name="model">phap.price.edit.wizard</field>
+        <field name="arch" type="xml"> 
+            <form>
+                <sheet>
+                    <field name="currency_id" invisible="1" />
+                    <group>
+                        <span name="warn_message">
+                            Changing price will fire later prices recalculation.
+                            This process could take unexpected time execution.
+                        </span>
+                    </group>
+                    <group>
+                        <group>
+                            <field name="average_price" />
+                        </group>
+                        <group>
+                            <field
+                                name="average_price_new" 
+                                required="1"
+                            />
+                        </group>
+                    </group>
+                    <footer>
+                        <button
+                            name="action_confirm"
+                            string="Confirm"
+                            type="object"
+                            class="oe_highlight"
+                        />
+                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/stock_valuation/wizards/phap_qty_edit.py
+++ b/stock_valuation/wizards/phap_qty_edit.py
@@ -1,0 +1,27 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3 - See https://www.gnu.org/licenses/lgpl-3.0.html
+
+from odoo import api, fields, models
+
+
+class PhapQtyEditWizard(models.TransientModel):
+    _name = "phap.qty.edit.wizard"
+    _description = "PHAP Quantity Edit Wizard"
+
+    phap_id = fields.Many2one("product.history.average.price", readonly=True)
+    location_id = fields.Many2one(related="phap_id.warehouse_id.lot_stock_id")
+    stock_quantity = fields.Float(
+        related="phap_id.stock_quantity",
+        string="Current stock quantity",
+    )
+    stock_quantity_new = fields.Float(
+        digits="Product Unit of Measure",
+        required=True,
+        string="New stock quantity",
+    )
+
+    def action_confirm(self):
+        self.ensure_one()
+        self.phap_id._update_quantity(
+            self.location_id, self.stock_quantity_new
+        )

--- a/stock_valuation/wizards/phap_qty_edit_views.xml
+++ b/stock_valuation/wizards/phap_qty_edit_views.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_phap_qty_edit_wizard_form" model="ir.ui.view">
+        <field name="name">phap.qty.edit.wizard form</field>
+        <field name="model">phap.qty.edit.wizard</field>
+        <field name="arch" type="xml"> 
+            <form>
+                <sheet>
+                    <group>
+                        <span name="warn_message">
+                            Changing quantity will fire later stock valuation recalculation.
+                            This process could take unexpected time execution.
+                            <p/>
+                            Making this action will add/remove to selected location the stock
+                            quantity as a result of the difference between current and desired
+                            quantity
+                        </span>
+                    </group>
+                    <group>
+                        <group>
+                            <field name="stock_quantity" />
+                            <field name="location_id" />
+                        </group>
+                        <group>
+                            <field name="stock_quantity_new" />
+                        </group>
+                    </group>
+                    <footer>
+                        <button
+                            name="action_confirm"
+                            string="Confirm"
+                            type="object"
+                            class="oe_highlight"
+                        />
+                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <!-- Decimal precision workaround
+         TODO set digits to 'Product Unit Of Measure' in field definition?
+    -->
+    <record id="view_phap_qty_edit_wizard_form_dp" model="ir.ui.view">
+        <field name="name">phap.qty.edit.wizard form dp</field>
+        <field name="model">phap.qty.edit.wizard</field>
+        <field
+            name="inherit_id"
+            ref="stock_valuation.view_phap_qty_edit_wizard_form"
+        />
+        <field name="arch" type="xml">
+            <field name="stock_quantity" position="attributes">
+                <attribute name="digits">[12,3]</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This improvement includes these features:
* Manual price change, as expected, fires general price recalculation for linked PHAPs a SVLs.
* Only users that belong to "Inventory: can edit history average price" group can edit the price.
* Price change auditory is enabled and shown in PHAP form.
* When a price is manually changed, date and user involved are saved too.
* Manual PHAP prices are shown highlighted in tree view, and can be located with a custom filter.

@ChristianSantamaria could you update Test environment with it? Thanks!!

----

Added new commit feature:
This improvement, as expected, fires general stock recalculation for later PHAPs.
The differente quantity between current and desired is assigned at date
to the default stock location for the selected warehouse.
This is because this view is for a selected warehouse, not location, and at this
point it's not possible selecting any location within the warehouse.