### PR TITLE
[13.0][IMP] stock_valuation: added SVL type and related partner

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.1.0",
+    "version": "13.0.3.2.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/i18n/es.po
+++ b/stock_valuation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 17:46+0000\n"
-"PO-Revision-Date: 2023-02-10 17:46+0000\n"
+"POT-Creation-Date: 2023-02-16 09:36+0000\n"
+"PO-Revision-Date: 2023-02-16 09:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,6 +31,31 @@ msgstr ""
 "            - 1 si es positivo\n"
 "            - 0 si es cero\n"
 "            - -1 if si es negativo\n"
+"        "
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_stock_valuation_layer__origin_type
+msgid ""
+"\n"
+"        Possible types:\n"
+"        - purchase - comes from a purchase or purchase return\n"
+"        - sale - comes from a sale or sale return\n"
+"        - internal - internal transfer\n"
+"        - adjustment - Inventory adjustment\n"
+"        - scrap - Scrap\n"
+"        - mrp - comes from a production\n"
+"        - unbuild - comes from an unbuild\n"
+"        "
+msgstr ""
+"\n"
+"        Posibles tipos:\n"
+"        - purchase - compra o devolución de una compra\n"
+"        - sale - venta o devolución de una venta\n"
+"        - internal - transferencia interna\n"
+"        - adjustment - ajuste de inventario\n"
+"        - scrap - desecho\n"
+"        - mrp - Producción\n"
+"        - unbuild - Despiece\n"
 "        "
 
 #. module: stock_valuation
@@ -72,6 +97,11 @@ msgstr "Acumulado"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction
 msgid "Action Needed"
 msgstr "Acción necesaria"
+
+#. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__adjustment
+msgid "Adjustment"
+msgstr "Ajuste de inventario"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_attachment_count
@@ -324,6 +354,11 @@ msgid "If checked, some messages have a delivery error."
 msgstr "Cuando está marcado, algunos mensajes tienen error de envío"
 
 #. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__internal
+msgid "Internal"
+msgstr "Transferencia interna"
+
+#. module: stock_valuation
 #: model:res.groups,name:stock_valuation.group_stock_history_average_price_edit
 msgid "Inventory: can edit history average price"
 msgstr "Inventario: puede editar el precio medio histórico"
@@ -477,6 +512,11 @@ msgid "PHAP Quantity Edit Wizard"
 msgstr "Asistente de edición de cantidad en stock"
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__origin_partner_id
+msgid "Partner"
+msgstr "Contacto"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__phap_id
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__phap_id
 msgid "Phap"
@@ -558,6 +598,11 @@ msgid "Product Template"
 msgstr "Plantilla de producto"
 
 #. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__purchase
+msgid "Purchase"
+msgstr "Compra"
+
+#. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_purchase_order_line
 msgid "Purchase Order Line"
 msgstr "Línea de pedido de compra"
@@ -582,6 +627,16 @@ msgstr "Referencia"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr "Error de envío de SMS"
+
+#. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__sale
+msgid "Sale"
+msgstr "Venta"
+
+#. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__scrap
+msgid "Scrap"
+msgstr "Desecho"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_average_price_date_wizard_form
@@ -689,6 +744,12 @@ msgstr "Total acum. en entradas"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__total_quantity_day
 msgid "Total inputs"
 msgstr "Total entradas"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__origin_type
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_search_inherit
+msgid "Type"
+msgstr "Tipo"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread

--- a/stock_valuation/i18n/stock_valuation.pot
+++ b/stock_valuation/i18n/stock_valuation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 17:45+0000\n"
-"PO-Revision-Date: 2023-02-10 17:45+0000\n"
+"POT-Creation-Date: 2023-02-16 09:36+0000\n"
+"PO-Revision-Date: 2023-02-16 09:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -24,6 +24,21 @@ msgid ""
 "            - 1 if is positive\n"
 "            - 0 if is zero\n"
 "            - -1 if is negative\n"
+"        "
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,help:stock_valuation.field_stock_valuation_layer__origin_type
+msgid ""
+"\n"
+"        Possible types:\n"
+"        - purchase - comes from a purchase or purchase return\n"
+"        - sale - comes from a sale or sale return\n"
+"        - internal - internal transfer\n"
+"        - adjustment - Inventory adjustment\n"
+"        - scrap - Scrap\n"
+"        - mrp - comes from a production\n"
+"        - unbuild - comes from an unbuild\n"
 "        "
 msgstr ""
 
@@ -61,6 +76,11 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_needaction
 msgid "Action Needed"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__adjustment
+msgid "Adjustment"
 msgstr ""
 
 #. module: stock_valuation
@@ -307,6 +327,11 @@ msgid "If checked, some messages have a delivery error."
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__internal
+msgid "Internal"
+msgstr ""
+
+#. module: stock_valuation
 #: model:res.groups,name:stock_valuation.group_stock_history_average_price_edit
 msgid "Inventory: can edit history average price"
 msgstr ""
@@ -458,6 +483,11 @@ msgid "PHAP Quantity Edit Wizard"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__origin_partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_price_edit_wizard__phap_id
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__phap_id
 msgid "Phap"
@@ -539,6 +569,11 @@ msgid "Product Template"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__purchase
+msgid "Purchase"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_purchase_order_line
 msgid "Purchase Order Line"
 msgstr ""
@@ -562,6 +597,16 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_sms_error
 msgid "SMS Delivery error"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__sale
+msgid "Sale"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__scrap
+msgid "Scrap"
 msgstr ""
 
 #. module: stock_valuation
@@ -666,6 +711,12 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__total_quantity_day
 msgid "Total inputs"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__origin_type
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_search_inherit
+msgid "Type"
 msgstr ""
 
 #. module: stock_valuation

--- a/stock_valuation/migrations/13.0.3.2.0/pre-migration.py
+++ b/stock_valuation/migrations/13.0.3.2.0/pre-migration.py
@@ -1,0 +1,47 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(
+        env.cr, "stock_valuation_layer", "origin_type"
+    ):
+        openupgrade.logged_query(
+            env.cr,
+            """ALTER TABLE stock_valuation_layer
+            ADD COLUMN origin_type character varying
+            """,
+        )
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE
+                stock_valuation_layer
+            SET
+                origin_type=case
+                    when sm.purchase_line_id is not null then 'purchase'
+                    when sm.sale_line_id is not null then 'sale'
+                    when sm.scrapped is true then 'scrap'
+                    when spt.code = 'internal' then 'internal'
+                    when slo.usage = 'inventory' or sld.usage = 'inventory' then 'adjustment'
+                    else ''
+                end
+            FROM
+                stock_valuation_layer svl
+            INNER JOIN
+                stock_move sm on sm.id=svl.stock_move_id
+            INNER JOIN
+                stock_location slo on slo.id=sm.location_id
+            INNER JOIN
+                stock_location sld on sld.id=sm.location_dest_id
+            LEFT JOIN
+                stock_picking sp on sp.id=sm.picking_id
+            LEFT JOIN
+                stock_picking_type spt on spt.id=sp.picking_type_id
+            WHERE
+                stock_valuation_layer.id = svl.id
+            """,
+        )

--- a/stock_valuation/views/stock_valuation_layer_views.xml
+++ b/stock_valuation/views/stock_valuation_layer_views.xml
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record
+        id="stock_account.action_stock_inventory_valuation"
+        model="ir.actions.act_window"
+    >
+        <field name="context">{
+            'search_default_group_by_product_id': 1,
+            'hide_origin_partner_id': True,
+        }</field>
+    </record>
+
     <record id="view_stock_valuation_layer_tree_inherit" model="ir.ui.view">
         <field name="name">stock.valuation.layer.tree.inherit (stock valuation)</field>
         <field name="model">stock.valuation.layer</field>
         <field name="inherit_id" ref="stock_account.stock_valuation_layer_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='create_date']" position="after">
-                <field name="warehouse_id" />
+                <field
+                    name="warehouse_id"
+                    optional="hide"
+                />
+                <field name="origin_type"
+                    optional="hide"
+                />
                 <field name="document_origin" />
                 <field name="move_reference" />                
+                <!-- This field is computed non-stored, by default (tree general
+                     action) is not shown -->
+                <field
+                    name="origin_partner_id"
+                    optional="hide"
+                    invisible="context.get('hide_origin_partner_id', False)"
+                />
             </xpath>
             <xpath expr="//field[@name='uom_id']" position="after">
                 <field name="unit_cost" />
@@ -41,11 +64,13 @@
         <field name="inherit_id" ref="stock_account.view_inventory_valuation_search"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_tmpl_id']" position="after">
+                <field name="origin_type" />
                 <field name="document_origin" />
                 <field name="move_reference" />
             </xpath>
             <xpath expr="//filter[@name='group_by_product_id']" position="after">
                 <filter string="Warehouse" name="group_by_warehouse_id" context="{'group_by': 'warehouse_id'}"/>
+                <filter string="Type" name="group_by_origin_type" context="{'group_by': 'origin_type'}"/>
             </xpath>
         </field>
     </record>
@@ -66,19 +91,25 @@
                     attrs="{'invisible': [('warehouse_valuation','=',False)]}"
                 >
                     <group>
-                        <field name="warehouse_id" />
-                        <field name="document_origin" />
-                        <field name="move_reference" />
-                        <field
-                            name="average_price"
-                            groups="base.group_no_one"
-                        />
-                        <field name="accumulated"/>
-                        <field name="is_return"/>
-                        <field
-                            name="history_average_price_id"
-                            groups="base.group_no_one"
-                        />
+                        <group>
+                            <field name="warehouse_id" />
+                            <field name="origin_type" />
+                            <field name="document_origin" />
+                            <field name="move_reference" />
+                            <field name="origin_partner_id" />
+                        </group>
+                        <group>
+                            <field
+                                name="average_price"
+                                groups="base.group_no_one"
+                            />
+                            <field name="accumulated"/>
+                            <field name="is_return"/>
+                            <field
+                                name="history_average_price_id"
+                                groups="base.group_no_one"
+                            />
+                        </group>                        
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
Stock valuation layer types are the following:
- purchase - comes from a purchase or purchase return
- sale - comes from a sale or sale return
- internal - internal transfer
- adjustment - Inventory adjustment
- scrap - Scrap

These values are stored in SLV record. SVL partner is obtaine as related from stock move, so is non-stored.
