### PR TITLE
[13.0][FIX] stock_valuation: done transfers cannot create new moves

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.2.0",
+    "version": "13.0.3.2.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/i18n/es.po
+++ b/stock_valuation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-16 09:36+0000\n"
-"PO-Revision-Date: 2023-02-16 09:36+0000\n"
+"POT-Creation-Date: 2023-02-17 12:49+0000\n"
+"PO-Revision-Date: 2023-02-17 12:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,16 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
 msgid "Cancel"
 msgstr "Cancelar"
+
+#. module: stock_valuation
+#: code:addons/stock_valuation/models/stock_move.py:0
+#, python-format
+msgid ""
+"Cannot add a move for %s in an done internal transfer. Please create a new "
+"transfer instead"
+msgstr ""
+"No está permitido añadir el movimiento para %s en una trasferencia interna "
+"completada. Por favor, cree una transferencia interna nueva en su lugar"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_product_history_average_price_form_edit

--- a/stock_valuation/i18n/stock_valuation.pot
+++ b/stock_valuation/i18n/stock_valuation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-16 09:36+0000\n"
-"PO-Revision-Date: 2023-02-16 09:36+0000\n"
+"POT-Creation-Date: 2023-02-17 12:48+0000\n"
+"PO-Revision-Date: 2023-02-17 12:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -149,6 +149,14 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_price_edit_wizard_form
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_phap_qty_edit_wizard_form
 msgid "Cancel"
+msgstr ""
+
+#. module: stock_valuation
+#: code:addons/stock_valuation/models/stock_move.py:0
+#, python-format
+msgid ""
+"Cannot add a move for %s in an done internal transfer. Please create a new "
+"transfer instead"
 msgstr ""
 
 #. module: stock_valuation


### PR DESCRIPTION
Before this fix, when a move was added to a done transfer, a done move was automatically created, bypassing stock valuation layer record creation, and stock quantity and valuation were affected.
With this fix, this operation is forbidden (user can create a new internal transfer at date), so the problem will lo longer occurs.