### PR TITLE
[13.0][FIX] stock_valuation: purchase order line price change to zero coverage

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.2.1",
+    "version": "13.0.3.2.2",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/models/purchase_order_line.py
+++ b/stock_valuation/models/purchase_order_line.py
@@ -13,7 +13,7 @@ class PurchaseOrderLine(models.Model):
         SVLs should be changed and linked PHAPs recomputed & SVLs updated
         """
         res = super().write(values)
-        if values.get("price_unit"):
+        if "price_unit" in values.keys():
             line_moves = self.env["stock.move"]
             affected_moves = self.env["stock.move"]
             for line in self.filtered(


### PR DESCRIPTION
Before this fix, when a POL price was changed to `0.0`, price recalculation was skipped. Since `0.0` is a price that should be allowed, this fix includes it.

@ChristianSantamaria could you update Test Environment with this fix?

cc @lmiguens-solvos 