### PR TITLE
[13.0][FIX] stock_valuation: archived products coverage

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.2.2",
+    "version": "13.0.3.2.3",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/models/stock_valuation_layer.py
+++ b/stock_valuation/models/stock_valuation_layer.py
@@ -8,6 +8,12 @@ import pdb
 class StockValuationLayer(models.Model):
     _inherit = "stock.valuation.layer"
 
+    # Original code at stock_account forces it to product_id.active,
+    #  we remove it, as active should be always be to True
+    # Anyway, we preserve original active flag, and use it in views
+    active = fields.Boolean(related="", default=True)
+    product_active = fields.Boolean(related="product_id.active")
+
     create_date_valuation = fields.Datetime(
         default=lambda self: fields.Datetime.now(),
         readonly=True,

--- a/stock_valuation/views/stock_valuation_layer_views.xml
+++ b/stock_valuation/views/stock_valuation_layer_views.xml
@@ -17,6 +17,7 @@
         <field name="inherit_id" ref="stock_account.stock_valuation_layer_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='create_date']" position="after">
+                <field name="product_active" invisible="1" />
                 <field
                     name="warehouse_id"
                     optional="hide"
@@ -43,6 +44,9 @@
                     name="history_average_price_id"
                     groups="base.group_no_one"
                 />
+            </xpath>
+            <xpath expr="." position="attributes">
+                <attribute name="decoration-muted">not product_active</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Stock valuation layers for inactive products are archived too in `stock_account` definition. With this fix, for our addon are restored as active, because we need them active for later recalculations.

cc @ChristianSantamaria @lmiguens-solvos 