### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: ticket creation - use net date for numbering

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.20.0",
+    "version": "13.0.1.21.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/report/stock_picking_tag_template.xml
+++ b/stock_picking_mgmt_weight/report/stock_picking_tag_template.xml
@@ -24,7 +24,7 @@
                                 </div>
                                 <div class="row mb-3">
                                     <div class="w-25">Date:</div>
-                                    <div class="w-75"><span t-esc="move.picking_id.get_datetime_now()" t-options="{'widget': 'datetime'}"/></div>
+                                    <div class="w-75"><span t-field="move.date_net_weight" t-options="{'widget': 'datetime'}"/></div>
                                 </div>
                                 <div class="row mb-3">
                                     <div class="w-25">License Plate:</div>


### PR DESCRIPTION
With this improvement, in report ticket proper date (tare for incoming weights and gross date for outgoing) is printed for general ticket print date.

Also, this date is used for ticket numbering, when date range is used in the correspondent stock picking sequence. This allows to create weight tickets in the past (e.g. last year) with the desired number according this date.