### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: purchase order line first invoice date - based on accounting date

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.21.0",
+    "version": "13.0.1.21.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/purchase_order_line.py
+++ b/stock_picking_mgmt_weight/models/purchase_order_line.py
@@ -249,9 +249,9 @@ class PurchaseOrderLine(models.Model):
         # TODO this computation doesn't look for related lines
         #      and their invoice dates
         for record in self:
-            moves = record.invoice_lines.mapped("move_id")
             record.invoice_lines_invoice_first_date = (
-                moves and moves.sorted("invoice_date")[0].invoice_date
+                record.invoice_lines
+                and record.invoice_lines.sorted("date")[0].date
                 or False
             )
 


### PR DESCRIPTION
Before this fix, for this calculation bill date was used, but accounting date is more accurate.