### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: enable Outgoing Info for internal transfers

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.21.1",
+    "version": "13.0.1.22.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,14 +6,29 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 12:33+0000\n"
-"PO-Revision-Date: 2022-12-13 12:33+0000\n"
+"POT-Creation-Date: 2023-06-28 12:45+0000\n"
+"PO-Revision-Date: 2023-06-28 12:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_picking__outgoing_info_enabled
+msgid ""
+"\n"
+"        Technical field that is used in 'Outgoing Info' management\n"
+"        (that block is only shown for outgoing operations, or internal\n"
+"        between warehouses)\n"
+"        "
+msgstr ""
+"\n"
+"        Campo técnico para la gestión de 'Info. Salida'\n"
+"        (dicho bloque solo se muestra para operaciones de salida o\n"
+"        internas entre almacenes)\n"
+"        "
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__picking_state
@@ -950,6 +965,11 @@ msgid "Net"
 msgstr "Neto"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move__date_net_weight
+msgid "Net weight date"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.label_transfer_template_view_pdf
 msgid "Net:"
 msgstr "Neto:"
@@ -1058,6 +1078,11 @@ msgstr "Báscula de tipo de salida"
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit
 msgid "Outgoing Info"
 msgstr "Info. salida"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_picking__outgoing_info_enabled
+msgid "Outgoing Info Enabled"
+msgstr "Info. Salida habilitado"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_move_search_weight

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,14 +6,32 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 12:32+0000\n"
-"PO-Revision-Date: 2022-12-13 12:32+0000\n"
+"POT-Creation-Date: 2023-06-28 12:44+0000\n"
+"PO-Revision-Date: 2023-06-28 12:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__date_net_weight
+msgid ""
+"\n"
+"        Shows date for last registered weight (gross or tare)\n"
+"        "
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_picking__outgoing_info_enabled
+msgid ""
+"\n"
+"        Technical field that is used in 'Outgoing Info' management\n"
+"        (that block is only shown for outgoing operations, or internal\n"
+"        between warehouses)\n"
+"        "
+msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__picking_state
@@ -914,6 +932,11 @@ msgid "Net"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move__date_net_weight
+msgid "Net weight date"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.label_transfer_template_view_pdf
 msgid "Net:"
 msgstr ""
@@ -1021,6 +1044,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit
 msgid "Outgoing Info"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_picking__outgoing_info_enabled
+msgid "Outgoing Info Enabled"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/views/stock_picking_views.xml
+++ b/stock_picking_mgmt_weight/views/stock_picking_views.xml
@@ -9,6 +9,7 @@
             <xpath expr="//group/field[@name='backorder_id']" position="after">
                 <field name="type_scale" invisible="1"/>
                 <field name="type_code" invisible="1"/>
+                <field name="outgoing_info_enabled" invisible="1"/>            
                 <field name="vehicle_id" attrs="{'invisible': [('type_scale', '=', False)]}"/>
                 <field name="towing_license_plate" attrs="{'invisible': [('type_scale', '=', False)]}"/>
             </xpath>
@@ -44,7 +45,7 @@
                 <page
                     string="Outgoing Info"
                     name="outgoing_info"
-                    attrs="{'invisible': [('type_code','!=','outgoing')]}"
+                    attrs="{'invisible': [('outgoing_info_enabled','=',False)]}"
                 >
                     <group name="outgoing_info_gr_main">
                         <group name="outgoing_info_gr_1" string="Container">


### PR DESCRIPTION
With this improvement, that information is also enabled for internal transfers, when location warehouses aren't the same.