### PR TITLE
[13.0][IMP+FIX] stock_picking_mgmt_weight: added supply condition for purchase lines // prevent picking copy values

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.23.1",
+    "version": "13.0.1.24.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.24.0",
+    "version": "13.0.1.24.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,14 +6,33 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 12:45+0000\n"
-"PO-Revision-Date: 2023-06-28 12:45+0000\n"
+"POT-Creation-Date: 2024-02-27 17:36+0000\n"
+"PO-Revision-Date: 2024-02-27 17:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move_weight_wizard__purchase_internal_notes
+msgid ""
+"\n"
+"        Obtains concatenated related purchases notes\n"
+"        "
+msgstr ""
+"\n"
+"        Obtiene una lista con las notas internas de los pedidos relacionados\n"
+"        "
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__date_net_weight
+msgid ""
+"\n"
+"        Shows date for last registered weight (gross or tare)\n"
+"        "
+msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_picking__outgoing_info_enabled
@@ -28,17 +47,6 @@ msgstr ""
 "        Campo técnico para la gestión de 'Info. Salida'\n"
 "        (dicho bloque solo se muestra para operaciones de salida o\n"
 "        internas entre almacenes)\n"
-"        "
-
-#. module: stock_picking_mgmt_weight
-#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move_weight_wizard__purchase_internal_notes
-msgid ""
-"\n"
-"        Obtains concatenated related purchases notes\n"
-"        "
-msgstr ""
-"\n"
-"        Obtiene una lista con las notas internas de los pedidos relacionados\n"
 "        "
 
 #. module: stock_picking_mgmt_weight
@@ -67,6 +75,7 @@ msgstr ""
 " * Cancelado: la transferencia ha sido cancelada."
 
 #. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #, python-format
 msgid "%s-%s (%.2f pend.)"
@@ -470,7 +479,7 @@ msgstr "Peso completo"
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_res_config_settings
 msgid "Config Settings"
-msgstr "Ajustes de configuración"
+msgstr "Opciones de Configuración"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.ui.menu,name:stock_picking_mgmt_weight.menu_mgmt_weight_configuration
@@ -1185,7 +1194,7 @@ msgstr "Cantidad de Producto SoloLectura"
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_product_template
 msgid "Product Template"
-msgstr "Plantilla de producto"
+msgstr "Producto"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.label_transfer_template_view_pdf
@@ -1206,7 +1215,7 @@ msgstr "Observaciones internas en pedidos"
 #: model:ir.model,name:stock_picking_mgmt_weight.model_purchase_order
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__purchase_order_id
 msgid "Purchase Order"
-msgstr "Pedido de compra"
+msgstr "Orden de Compra"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_purchase_order_line
@@ -1439,7 +1448,7 @@ msgstr "Estado"
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__move_id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_line_weight_wizard__move_weight_id
 msgid "Stock Move"
-msgstr "Movimiento de Inventario"
+msgstr "Movimiento de existencias"
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_move_line_form_weight
@@ -1455,11 +1464,14 @@ msgstr "Clasificación de albarán de inventario"
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Supp. Cond."
 msgstr "Cond. Suministro"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_supply_condition
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__supply_condition_id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__supply_condition_id
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_supply_condition_form
 msgid "Supply Condition"
@@ -1650,7 +1662,7 @@ msgstr "Matricula remolque:"
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_stock_picking
 msgid "Transfer"
-msgstr "Transferencia"
+msgstr "Albarán"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_vehicle_vehicle__transfer_count

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,14 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 12:44+0000\n"
-"PO-Revision-Date: 2023-06-28 12:44+0000\n"
+"POT-Creation-Date: 2024-02-27 17:36+0000\n"
+"PO-Revision-Date: 2024-02-27 17:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move_weight_wizard__purchase_internal_notes
+msgid ""
+"\n"
+"        Obtains concatenated related purchases notes\n"
+"        "
+msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__date_net_weight
@@ -34,22 +42,6 @@ msgid ""
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move_weight_wizard__purchase_internal_notes
-msgid ""
-"\n"
-"        Obtains concatenated related purchases notes\n"
-"        "
-msgstr ""
-
-#. module: stock_picking_mgmt_weight
-#: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__date_net_weight
-msgid ""
-"\n"
-"        Shows date for last registered weight (gross or tare)\n"
-"        "
-msgstr ""
-
-#. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_stock_move__picking_state
 msgid ""
 " * Draft: The transfer is not confirmed yet. Reservation doesn't apply.\n"
@@ -65,6 +57,7 @@ msgid ""
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #, python-format
 msgid "%s-%s (%.2f pend.)"
@@ -1425,11 +1418,14 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_line_tree
+#: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_purchase_order_weight_form_inherit
 msgid "Supp. Cond."
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_supply_condition
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_purchase_order_line__supply_condition_id
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_sale_order_line__supply_condition_id
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_supply_condition_form
 msgid "Supply Condition"

--- a/stock_picking_mgmt_weight/models/purchase_order_line.py
+++ b/stock_picking_mgmt_weight/models/purchase_order_line.py
@@ -101,6 +101,7 @@ class PurchaseOrderLine(models.Model):
     order_user_id = fields.Many2one(related="order_id.user_id")
     order_incoterm_id = fields.Many2one(related="order_id.incoterm_id")
 
+    supply_condition_id = fields.Many2one(comodel_name="supply.condition")
     order_shipping_resource_id = fields.Many2one(related="order_id.shipping_resource_id")
 
     def name_get(self):

--- a/stock_picking_mgmt_weight/models/stock_picking.py
+++ b/stock_picking_mgmt_weight/models/stock_picking.py
@@ -15,6 +15,7 @@ class StockPicking(models.Model):
         'vehicle.vehicle',
         string='Vehicle',
         ondelete="restrict",
+        copy=False,
     )
     # TODO related, computed, a regular field?
     # carrier_vehicle_id = fields.Many2one(related="vehicle_id.carrier_id")
@@ -26,8 +27,9 @@ class StockPicking(models.Model):
         domain="[('is_company', '=', True)]",
         ondelete="restrict",
     )
-    towing_license_plate = fields.Char()
+    towing_license_plate = fields.Char(copy=False)
     container_number = fields.Char(
+        copy=False,
         help="A text representing container no. for an outgoing operation",
     )
     container_tare = fields.Float(

--- a/stock_picking_mgmt_weight/views/purchase_order_line_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_line_views.xml
@@ -58,7 +58,14 @@
                     widget="many2onebutton"
                     string="Orig."
                 />
-            </xpath>            
+            </xpath>
+            <field name="name" position="after">
+                <field
+                    name="supply_condition_id"
+                    optional="show"
+                    string="Supp. Cond."
+                />
+            </field>
             <xpath expr="//field[@name='product_qty']" position="after">
                 <field name="order_user_id" string="Repr."/>
                 <field name="qty_received" string="Received" optional="hide"/>

--- a/stock_picking_mgmt_weight/views/purchase_order_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_views.xml
@@ -88,6 +88,12 @@
             </xpath>
             <xpath expr="//tree/field[@name='name']" position="after">
                 <field
+                    name="supply_condition_id"
+                    optional="show"
+                    string="Supp. Cond."
+                    options="{'no_create_edit': True, 'no_create': True}"
+                />
+                <field
                     name="identification_document_number"
                     optional="hide"
                     attrs="{'invisible': [('state', 'not in', ('purchase', 'done'))]}"


### PR DESCRIPTION
Changes included:
* Added supply condition for purchase lines.
* When creating backorder or picking return, most values or original picking are copied, so they should be defined with `copy=False` if When want to prevent it. With this fix some of them are disabled for copy.