### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: show consistent line quantities when editing

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.24.1",
+    "version": "13.0.1.24.2",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/views/purchase_order_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_views.xml
@@ -104,6 +104,7 @@
                 <attribute name="attrs">{"optional": "hide"}</attribute>
             </xpath>
             <xpath expr="//tree/field[@name='qty_received']" position="after">
+                <field name="classification_order_line_ids" invisible="1"/>
                 <field name="qty_received_ext" string="Received*"/>
                 <field name="pending_qty" string="Pending"/>
                 <field


### PR DESCRIPTION
Before this fix, during PO edition, if line quantity changes, other computed stored quantities are temporary shown wrong. This is solved when PO is finally saved. This commit fixes this annoying behavior.

cc @ChristianSantamaria 