### PR TITLE
[13.0][IMP] logistics_planning_[purchase|sale]: default order value parametrization for "enable planning creation"

### DIFF
--- a/logistics_planning_purchase/__manifest__.py
+++ b/logistics_planning_purchase/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.0.1',
+    'version': '13.0.1.1.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [
@@ -17,6 +17,7 @@
     "data": [
         "views/logistics_schedule_views.xml",
         "views/purchase_order_views.xml",
+        "views/stock_picking_type_views.xml",
         "wizards/logistics_schedule_purchase_add_wizard_views.xml",
     ],
 }

--- a/logistics_planning_purchase/i18n/es.po
+++ b/logistics_planning_purchase/i18n/es.po
@@ -6,14 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-11 15:07+0000\n"
-"PO-Revision-Date: 2024-04-11 15:07+0000\n"
+"POT-Creation-Date: 2024-05-02 15:51+0000\n"
+"PO-Revision-Date: 2024-05-02 17:56+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,help:logistics_planning_purchase.field_purchase_order_line__ls_schedule_allowed
@@ -38,8 +40,25 @@ msgid ""
 "        "
 msgstr ""
 "\n"
-"        Campo técnico que permite saltarse la creación de las planificaciones\n"
+"        Campo técnico que permite saltarse la creación de las "
+"planificaciones\n"
 "        logísticas cuando se aprueba un pedido\n"
+"        "
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,help:logistics_planning_purchase.field_stock_picking_type__ls_po_create_disable_default
+msgid ""
+"\n"
+"        When checked, a PO created with this picking operation\n"
+"        won't create logistics plannings by default.\n"
+"        That could be changed for any PO anyway\n"
+"        "
+msgstr ""
+"\n"
+"        Cuando está marcado, al crear un PC con este tipo de operación de "
+"almacén\n"
+"        no se generarán las planificaciones logísticas por defecto.\n"
+"        Dicho comportamiento se podría cambiar en cada PC, en todo caso\n"
 "        "
 
 #. module: logistics_planning_purchase
@@ -80,6 +99,21 @@ msgid "Current schedule count"
 msgstr "Número actual de planificaciones"
 
 #. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_stock_picking_type__ls_po_create_disable_default
+msgid "Disable PO plannings creation by default"
+msgstr "Deshabilitar la creación de planificaciones para PCs por defecto"
+
+#. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.purchase_order_view_form_inherit_all
+msgid "Disable log. sched."
+msgstr "Deshab. planif. log."
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_purchase_order__logistics_schedule_disabled
+msgid "Disable logistics schedules creation"
+msgstr "Deshabilitar la creación de planificaciones logísticas"
+
+#. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__display_name
 msgid "Display Name"
 msgstr ""
@@ -93,6 +127,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_purchase_order_line__logistics_schedule_init
 msgid "Initial required schedules"
 msgstr "Nº inicial de planif. requeridas"
+
+#. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.view_pickingtype_filter
+msgid "LS PO Disabled by default"
+msgstr "Planificaciones logísticas deshabilitadas para PCs por defecto"
 
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard____last_update
@@ -166,6 +205,11 @@ msgid "Order Reference"
 msgstr "Ref. pedido"
 
 #. module: logistics_planning_purchase
+#: model:ir.model,name:logistics_planning_purchase.model_stock_picking_type
+msgid "Picking Type"
+msgstr "Tipo de Albarán"
+
+#. module: logistics_planning_purchase
 #: code:addons/logistics_planning_purchase/models/purchase_order.py:0
 #, python-format
 msgid ""
@@ -180,8 +224,8 @@ msgstr ""
 #, python-format
 msgid "Please fill a valid number of new schedules to be added (> 0)"
 msgstr ""
-"Por favor, rellene un número válido para las nuevas planificaciones a añadir"
-" (> 0)"
+"Por favor, rellene un número válido para las nuevas planificaciones a "
+"añadir (> 0)"
 
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__product_id

--- a/logistics_planning_purchase/i18n/logistics_planning_purchase.pot
+++ b/logistics_planning_purchase/i18n/logistics_planning_purchase.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-11 15:06+0000\n"
-"PO-Revision-Date: 2024-04-11 15:06+0000\n"
+"POT-Creation-Date: 2024-05-02 15:45+0000\n"
+"PO-Revision-Date: 2024-05-02 15:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -35,6 +35,17 @@ msgid ""
 msgstr ""
 
 #. module: logistics_planning_purchase
+#: model:ir.model.fields,help:logistics_planning_purchase.field_stock_picking_type__ls_po_create_disable_default
+msgid ""
+"\n"
+"        When checked, a PO created with this picking operation\n"
+"        won't create logistics plannings by default.\n"
+"        That could be changed for any PO anyway\n"
+"        "
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: code:addons/logistics_planning_purchase/models/purchase_order_line.py:0
 #: code:addons/logistics_planning_purchase/models/purchase_order_line.py:0
 #: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.purchase_order_view_form_inherit_all
 #, python-format
@@ -72,6 +83,21 @@ msgid "Current schedule count"
 msgstr ""
 
 #. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_stock_picking_type__ls_po_create_disable_default
+msgid "Disable PO plannings creation by default"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.purchase_order_view_form_inherit_all
+msgid "Disable log. sched."
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_purchase_order__logistics_schedule_disabled
+msgid "Disable logistics schedules creation"
+msgstr ""
+
+#. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__display_name
 msgid "Display Name"
 msgstr ""
@@ -84,6 +110,11 @@ msgstr ""
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_purchase_order_line__logistics_schedule_init
 msgid "Initial required schedules"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.view_pickingtype_filter
+msgid "LS PO Disabled by default"
 msgstr ""
 
 #. module: logistics_planning_purchase
@@ -158,6 +189,12 @@ msgid "Order Reference"
 msgstr ""
 
 #. module: logistics_planning_purchase
+#: model:ir.model,name:logistics_planning_purchase.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: code:addons/logistics_planning_purchase/models/purchase_order.py:0
 #: code:addons/logistics_planning_purchase/models/purchase_order.py:0
 #, python-format
 msgid ""

--- a/logistics_planning_purchase/models/__init__.py
+++ b/logistics_planning_purchase/models/__init__.py
@@ -2,3 +2,4 @@ from . import logistics_schedule
 from . import purchase_order_line
 from . import purchase_order
 from . import stock_picking
+from . import stock_picking_type

--- a/logistics_planning_purchase/models/purchase_order.py
+++ b/logistics_planning_purchase/models/purchase_order.py
@@ -1,7 +1,7 @@
 # © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -22,6 +22,17 @@ class PurchaseOrder(models.Model):
         creation during order approval
         """,
     )
+    logistics_schedule_disabled = fields.Boolean(
+        string="Disable logistics schedules creation",
+        default=False,
+        copy=False,
+        readonly=False,        
+        states={
+            "cancel": [("readonly", True)],
+            "done": [("readonly", True)],
+        },
+        tracking=True,
+    )
     logistics_account_move_ids = fields.Many2many(
         comodel_name="account.move",
         compute="_compute_logistics_account_moves",
@@ -34,6 +45,13 @@ class PurchaseOrder(models.Model):
     ls_transport_type = fields.Selection(
         related="incoterm_id.ls_sale_transport_type",
     )
+
+    @api.onchange("picking_type_id")
+    def _ls_onchange_picking_type_id(self):
+        if self.picking_type_id:
+            self.logistics_schedule_disabled = (
+                self.picking_type_id.ls_po_create_disable_default
+            )
 
     def _compute_logistics_account_moves(self):
         for po in self:

--- a/logistics_planning_purchase/models/purchase_order_line.py
+++ b/logistics_planning_purchase/models/purchase_order_line.py
@@ -41,6 +41,7 @@ class PurchaseOrderLine(models.Model):
         for line in self:
             line.ls_schedule_allowed = (
                 not line.logistics_schedule_skip
+                and not line.order_id.logistics_schedule_disabled
                 and not line.display_type
                 and line.product_id.type in ["product", "consu"]
                 and line.state in ["draft", "sent", "to approve", "purchase"]

--- a/logistics_planning_purchase/models/stock_picking_type.py
+++ b/logistics_planning_purchase/models/stock_picking_type.py
@@ -1,0 +1,18 @@
+# © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    ls_po_create_disable_default = fields.Boolean(
+        string="Disable PO plannings creation by default",
+        default=False,
+        help="""
+        When checked, a PO created with this picking operation
+        won't create logistics plannings by default.
+        That could be changed for any PO anyway
+        """,
+    )

--- a/logistics_planning_purchase/views/purchase_order_views.xml
+++ b/logistics_planning_purchase/views/purchase_order_views.xml
@@ -25,6 +25,12 @@
                     name="logistics_schedule_skip"
                     groups="base.group_no_one"
                 />
+                <field
+                    name="logistics_schedule_disabled"
+                    widget="boolean_toggle"
+                    string="Disable log. sched."
+                    attrs="{'invisible': [('logistics_schedule_skip','=',True)]}"
+                />
             </xpath>            
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='sequence']"

--- a/logistics_planning_purchase/views/stock_picking_type_views.xml
+++ b/logistics_planning_purchase/views/stock_picking_type_views.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pickingtype_filter" model="ir.ui.view">
+        <field name="name">stock.picking.type.filter (in logistics_planning_purchase)</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_pickingtype_filter"/>
+        <field
+            name="groups_id"
+            eval="[(4, ref('logistics_planning_base.group_lp_manager'))]"
+        />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator />
+                <filter
+                    string="LS PO Disabled by default"
+                    name="filter_ls_po_disabled_default"
+                    domain="[('ls_po_create_disable_default','=',True)]"
+                />
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">Operation Types (in logistics_planning_purchase)</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <field name="warehouse_id" position="after">
+                <field
+                    name="ls_po_create_disable_default"
+                    widget="boolean_toggle"
+                    attrs="{'invisible': [('code', '!=', 'incoming')]}"
+                    groups="logistics_planning_base.group_lp_manager"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_picking_type_tree" model="ir.ui.view">
+        <field name="name">Operation types (in logistics_planning_purchase)</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_tree"/>
+        <field name="arch" type="xml">
+            <field name="warehouse_id" position="after">
+                <field
+                    name="ls_po_create_disable_default"
+                    optional="hide"
+                    widget="boolean_toggle"
+                    groups="logistics_planning_base.group_lp_manager"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/logistics_planning_sale/__manifest__.py
+++ b/logistics_planning_sale/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.0.1',
+    'version': '13.0.1.1.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [
@@ -17,6 +17,7 @@
     "data": [
         "views/logistics_schedule_views.xml",
         "views/sale_order_views.xml",
+        "views/stock_warehouse_views.xml",
         "wizards/logistics_schedule_sale_add_wizard_views.xml",
     ],
 }

--- a/logistics_planning_sale/i18n/es.po
+++ b/logistics_planning_sale/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-19 12:24+0000\n"
-"PO-Revision-Date: 2024-04-19 14:25+0200\n"
+"POT-Creation-Date: 2024-05-02 15:52+0000\n"
+"PO-Revision-Date: 2024-05-02 17:54+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -25,6 +25,21 @@ msgid ""
 "        are allowed for this line\n"
 "        "
 msgstr ""
+
+#. module: logistics_planning_sale
+#: model:ir.model.fields,help:logistics_planning_sale.field_stock_warehouse__ls_so_create_disable_default
+msgid ""
+"\n"
+"        When checked, a SO created with destination this warehouse\n"
+"        won't create logistics plannings by default.\n"
+"        That could be changed for any SO anyway\n"
+"        "
+msgstr ""
+"\n"
+"        Cuando está marcado, al crear PV cuyo destino es este almacén\n"
+"        no se generarán las planificaciones logísticas por defecto.\n"
+"        Dicho comportamiento se podría cambiar en cada PV, en todo caso\n"
+"        "
 
 #. module: logistics_planning_sale
 #: code:addons/logistics_planning_sale/models/sale_order_line.py:0
@@ -64,6 +79,11 @@ msgid "Current schedule count"
 msgstr "Número actual de planificaciones"
 
 #. module: logistics_planning_sale
+#: model:ir.model.fields,field_description:logistics_planning_sale.field_stock_warehouse__ls_so_create_disable_default
+msgid "Disable SO plannings creation by default"
+msgstr "Deshabilitar la creación de planificaciones en PVs por defecto"
+
+#. module: logistics_planning_sale
 #: model_terms:ir.ui.view,arch_db:logistics_planning_sale.view_order_form_all
 msgid "Disable log. sched."
 msgstr "Deshab. planif. log."
@@ -92,6 +112,11 @@ msgstr "Id."
 #: model:ir.model.fields,field_description:logistics_planning_sale.field_sale_order_line__logistics_schedule_init
 msgid "Initial required schedules"
 msgstr "Nº inicial de planif. requeridas"
+
+#. module: logistics_planning_sale
+#: model_terms:ir.ui.view,arch_db:logistics_planning_sale.stock_warehouse_view_search
+msgid "LS Disabled by default"
+msgstr "Planificaciones logísticas deshabilitadas por defecto"
 
 #. module: logistics_planning_sale
 #: model:ir.model.fields,field_description:logistics_planning_sale.field_logistics_schedule_sale_add_wizard____last_update
@@ -238,6 +263,11 @@ msgstr "Viaje"
 #: model:ir.model.fields.selection,name:logistics_planning_sale.selection__sale_order_line__logistics_price_unit_type__unit
 msgid "Unit"
 msgstr "Unidad"
+
+#. module: logistics_planning_sale
+#: model:ir.model,name:logistics_planning_sale.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Almacén"
 
 #. module: logistics_planning_sale
 #: model:ir.model,name:logistics_planning_sale.model_logistics_schedule

--- a/logistics_planning_sale/i18n/logistics_planning_sale.pot
+++ b/logistics_planning_sale/i18n/logistics_planning_sale.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-19 12:24+0000\n"
-"PO-Revision-Date: 2024-04-19 12:24+0000\n"
+"POT-Creation-Date: 2024-05-02 15:51+0000\n"
+"PO-Revision-Date: 2024-05-02 15:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +21,16 @@ msgid ""
 "\n"
 "        Technical field that determines if logistics schedules\n"
 "        are allowed for this line\n"
+"        "
+msgstr ""
+
+#. module: logistics_planning_sale
+#: model:ir.model.fields,help:logistics_planning_sale.field_stock_warehouse__ls_so_create_disable_default
+msgid ""
+"\n"
+"        When checked, a SO created with destination this warehouse\n"
+"        won't create logistics plannings by default.\n"
+"        That could be changed for any SO anyway\n"
 "        "
 msgstr ""
 
@@ -62,6 +72,11 @@ msgid "Current schedule count"
 msgstr ""
 
 #. module: logistics_planning_sale
+#: model:ir.model.fields,field_description:logistics_planning_sale.field_stock_warehouse__ls_so_create_disable_default
+msgid "Disable SO plannings creation by default"
+msgstr ""
+
+#. module: logistics_planning_sale
 #: model_terms:ir.ui.view,arch_db:logistics_planning_sale.view_order_form_all
 msgid "Disable log. sched."
 msgstr ""
@@ -89,6 +104,11 @@ msgstr ""
 #. module: logistics_planning_sale
 #: model:ir.model.fields,field_description:logistics_planning_sale.field_sale_order_line__logistics_schedule_init
 msgid "Initial required schedules"
+msgstr ""
+
+#. module: logistics_planning_sale
+#: model_terms:ir.ui.view,arch_db:logistics_planning_sale.stock_warehouse_view_search
+msgid "LS Disabled by default"
 msgstr ""
 
 #. module: logistics_planning_sale
@@ -163,6 +183,7 @@ msgstr ""
 
 #. module: logistics_planning_sale
 #: code:addons/logistics_planning_sale/models/sale_order.py:0
+#: code:addons/logistics_planning_sale/models/sale_order.py:0
 #, python-format
 msgid ""
 "Please fill a valid Initial required schedules (>=0) for every order line "
@@ -230,6 +251,11 @@ msgstr ""
 #: model:ir.model.fields.selection,name:logistics_planning_sale.selection__logistics_schedule_sale_add_wizard__logistics_price_unit_type__unit
 #: model:ir.model.fields.selection,name:logistics_planning_sale.selection__sale_order_line__logistics_price_unit_type__unit
 msgid "Unit"
+msgstr ""
+
+#. module: logistics_planning_sale
+#: model:ir.model,name:logistics_planning_sale.model_stock_warehouse
+msgid "Warehouse"
 msgstr ""
 
 #. module: logistics_planning_sale

--- a/logistics_planning_sale/models/__init__.py
+++ b/logistics_planning_sale/models/__init__.py
@@ -3,3 +3,4 @@ from . import sale_order_line
 from . import sale_order
 from . import stock_picking
 from . import stock_move
+from . import stock_warehouse

--- a/logistics_planning_sale/models/sale_order.py
+++ b/logistics_planning_sale/models/sale_order.py
@@ -1,7 +1,7 @@
 # © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -34,6 +34,13 @@ class SaleOrder(models.Model):
         compute="_compute_logistics_account_moves",
         string="Logistics Bill Count",
     )
+
+    @api.onchange("warehouse_id")
+    def _ls_onchange_warehouse_id(self):
+        if self.warehouse_id:
+            self.logistics_schedule_disabled = (
+                self.warehouse_id.ls_so_create_disable_default
+            )
 
     def _compute_logistics_account_moves(self):
         for so in self:

--- a/logistics_planning_sale/models/stock_warehouse.py
+++ b/logistics_planning_sale/models/stock_warehouse.py
@@ -1,0 +1,18 @@
+# © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import api, fields, models
+
+
+class StockWarehouse(models.Model):
+    _inherit = "stock.warehouse"
+
+    ls_so_create_disable_default = fields.Boolean(
+        string="Disable SO plannings creation by default",
+        default=False,
+        help="""
+        When checked, a SO created with destination this warehouse
+        won't create logistics plannings by default.
+        That could be changed for any SO anyway
+        """,
+    )

--- a/logistics_planning_sale/views/stock_warehouse_views.xml
+++ b/logistics_planning_sale/views/stock_warehouse_views.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_warehouse_view_search" model="ir.ui.view">
+        <field name="name">stock.warehouse.search (in logistics_planning_sale)</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.stock_warehouse_view_search"/>
+        <field
+            name="groups_id"
+            eval="[(4, ref('logistics_planning_base.group_lp_manager'))]"
+        />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator />
+                <filter
+                    string="LS Disabled by default"
+                    name="filter_ls_so_disabled_default"
+                    domain="[('ls_so_create_disable_default','=',True)]"
+                />
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_warehouse" model="ir.ui.view">
+        <field name="name">stock.warehouse (in logistics_planning_sale)</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse"/>
+        <field name="arch" type="xml">
+            <field name="code" position="after">
+                <field
+                    name="ls_so_create_disable_default"
+                    widget="boolean_toggle"
+                    groups="logistics_planning_base.group_lp_manager"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_warehouse_tree" model="ir.ui.view">
+        <field name="name">stock.warehouse.tree (in logistics_planning_sale)</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse_tree"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field
+                    name="ls_so_create_disable_default"
+                    optional="hide"
+                    widget="boolean_toggle"
+                    groups="logistics_planning_base.group_lp_manager"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purchase orders:
* This improvement adds a check that enables optional logistics planning creation during PO creation. Default value can be defined by picking operation.

Sale orders:
* This improvement enables default setting for enable planning creation during SO creation. This default value is set by sales order warehouse