### PR TITLE
[13.0][IMP] logistics_planning_sale: soft stock move link in sales schedules

### DIFF
--- a/logistics_planning_sale/__manifest__.py
+++ b/logistics_planning_sale/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.3.0',
+    'version': '13.0.1.4.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_sale/models/stock_move.py
+++ b/logistics_planning_sale/models/stock_move.py
@@ -12,3 +12,12 @@ class StockMove(models.Model):
         related="sale_line_id.order_id.logistics_schedule_disabled",
         string="Sale order - logistics schedule generation disabled",
     )
+
+    # TODO make it stored if becomes slow
+    rel_sale_order_id = fields.Many2one(
+        related="sale_line_id.order_id",
+        string="Related Sale Order",
+        help="""
+        Technical field used for logistics schedule stock move view domain
+        """,
+    )

--- a/logistics_planning_sale/views/logistics_schedule_views.xml
+++ b/logistics_planning_sale/views/logistics_schedule_views.xml
@@ -28,7 +28,7 @@
                     join_operator="AND"
                 >[
                     '|',
-                        ('sale_line_id', '=', sale_order_line_id),
+                        ('rel_sale_order_id', '=', sale_order_id),
                         '&amp;',
                             ('sale_line_id', '!=', False),
                             ('ls_sale_disabled', '=', True),
@@ -60,7 +60,7 @@
                 <field name="sale_order_line_id" invisible="1" />
             </xpath>
             <field name="stock_move_id" position="attributes">
-                <!-- Moves linked to our sales order line, or linked to those
+                <!-- Moves linked to our sales order, or linked to those
                      sale lines with planning disabled
                 -->
                 <attribute
@@ -70,7 +70,7 @@
                     join_operator="AND"
                 >[
                     '|',
-                        ('sale_line_id', '=', sale_order_line_id),
+                        ('rel_sale_order_id', '=', sale_order_id),
                         '&amp;',
                             ('sale_line_id', '!=', False),
                             ('ls_sale_disabled', '=', True),


### PR DESCRIPTION
Before this improvement, a stock move can be linked to a logistics schedule that comes from a sales order if sales line matches.

After this improvement, only sale order match is required, so a move that comes from a different sale line (but same sale order) and same product could be linked to LS. This is very useful for sale orders that have several lines with the same product, that generate identic LSs

@ChristianSantamaria could you install it at AluTest environment, so both you and me can test it?