### PR TITLE
[13.0][IMP] logistics_planning_*: manual input sched mark as finished support + multiticket

### DIFF
--- a/logistics_planning_base/__manifest__.py
+++ b/logistics_planning_base/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.1.1',
+    'version': '13.0.1.2.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': ["stock", "base_view_inheritance_extension"],

--- a/logistics_planning_base/i18n/es.po
+++ b/logistics_planning_base/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 06:21+0000\n"
-"PO-Revision-Date: 2024-05-22 08:34+0200\n"
+"POT-Creation-Date: 2024-05-27 15:32+0000\n"
+"PO-Revision-Date: 2024-05-27 17:34+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -352,6 +352,11 @@ msgstr "Administrador"
 #: model_terms:ir.ui.view,arch_db:logistics_planning_base.logistics_schedule_view_form
 msgid "Mark as Done"
 msgstr "Marcar como hecho"
+
+#. module: logistics_planning_base
+#: model:ir.actions.server,name:logistics_planning_base.action_logistics_schedule_sched_finished
+msgid "Mark as Finished"
+msgstr "Marcar como finalizado"
 
 #. module: logistics_planning_base
 #: model:ir.actions.server,name:logistics_planning_base.action_logistics_schedule_ready

--- a/logistics_planning_base/i18n/logistics_planning_base.pot
+++ b/logistics_planning_base/i18n/logistics_planning_base.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 06:20+0000\n"
-"PO-Revision-Date: 2024-05-22 06:20+0000\n"
+"POT-Creation-Date: 2024-05-27 15:32+0000\n"
+"PO-Revision-Date: 2024-05-27 15:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -335,6 +335,11 @@ msgstr ""
 #: model:ir.actions.server,name:logistics_planning_base.action_logistics_schedule_done
 #: model_terms:ir.ui.view,arch_db:logistics_planning_base.logistics_schedule_view_form
 msgid "Mark as Done"
+msgstr ""
+
+#. module: logistics_planning_base
+#: model:ir.actions.server,name:logistics_planning_base.action_logistics_schedule_sched_finished
+msgid "Mark as Finished"
 msgstr ""
 
 #. module: logistics_planning_base

--- a/logistics_planning_base/models/logistics_schedule.py
+++ b/logistics_planning_base/models/logistics_schedule.py
@@ -158,10 +158,14 @@ class LogisticsSchedule(models.Model):
     def _onchange_stock_move_id(self):
         self.ensure_one()
         if self.stock_move_id:
+            sched_finish = (
+                self.type == "output"
+                or self.env.context.get("sched_finish_input_auto", True)
+            )
             date_field = "commitment_date" if self.type == 'output' else "effective_date"
             self.write({
                 date_field: self.stock_move_id.date,
-                "schedule_finished": True,
+                "schedule_finished": sched_finish,
             }) 
 
     @api.onchange("carrier_id")
@@ -218,6 +222,9 @@ class LogisticsSchedule(models.Model):
     def action_logistics_schedule_cancel(self):
         self.browse(self.env.context.get("active_ids", []))._action_cancel()
 
+    def action_logistics_schedule_finished(self):
+        self.browse(self.env.context.get("active_ids", []))._action_sched_finished()
+
     def action_logistics_schedule_done(self):
         self.browse(self.env.context.get("active_ids", []))._action_done()
 
@@ -255,6 +262,23 @@ class LogisticsSchedule(models.Model):
         })
         return to_cancel
 
+    def _check_safe_finished(self):
+        # TO BE OVERRIDEN by addons that inherit from this one
+        pass
+
+    def _action_sched_finished(self):
+        # sudo access will be needed for logistics_planning_mgmt_weight limited
+        #  access users
+        to_sched_finished = self.sudo().filtered(
+            lambda x: (
+                not x.schedule_finished
+                and x.state == "ready"
+                and x.stock_move_id
+            )
+        )
+        to_sched_finished.write({"schedule_finished": True})
+        return to_sched_finished
+
     def _action_done(self, skip_can_set_to_done=False):
         to_done = self
         if not skip_can_set_to_done:
@@ -275,6 +299,8 @@ class LogisticsSchedule(models.Model):
         return to_done
 
     def write(self, values):
+        if values.get("schedule_finished", False):
+            self._check_safe_finished()
         if "stock_move_id" in values:
             # We assume that only a record is selected, no "expected singleton" should be fired
             # (1) If there was a previous stock move linked, ls should be unlinked

--- a/logistics_planning_base/views/logistics_schedule_views.xml
+++ b/logistics_planning_base/views/logistics_schedule_views.xml
@@ -11,6 +11,16 @@
             action = model.action_logistics_schedule_ready()
         </field>
     </record>
+    <record id="action_logistics_schedule_sched_finished" model="ir.actions.server">
+        <field name="name">Mark as Finished</field>
+        <field name="model_id" ref="model_logistics_schedule" />
+        <field name="binding_model_id" ref="model_logistics_schedule" />
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = model.action_logistics_schedule_finished()
+        </field>
+    </record>
     <record id="action_logistics_schedule_done" model="ir.actions.server">
         <field name="name">Mark as Done</field>
         <field name="model_id" ref="model_logistics_schedule" />

--- a/logistics_planning_invoicing/__manifest__.py
+++ b/logistics_planning_invoicing/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.0.0',
+    'version': '13.0.1.1.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': [

--- a/logistics_planning_invoicing/models/logistics_schedule.py
+++ b/logistics_planning_invoicing/models/logistics_schedule.py
@@ -43,14 +43,11 @@ class LogisticsSchedule(models.Model):
                 to_ready._action_ready()
         return ret
 
-    @api.onchange("stock_move_id")
-    def _onchange_stock_move_id(self):
-        super()._onchange_stock_move_id()
-        if (
-            self.schedule_finished
-            and self.incoterm_id.ls_invoice_disabled
-        ):
-            self.is_finished = True
+    @api.onchange("schedule_finished")
+    def _onchange_schedule_finished(self):
+        self.filtered(
+            lambda x: x.schedule_finished and x.incoterm_id.ls_invoice_disabled
+        ).write({"is_finished": True})
 
     @api.depends("account_move_line_id", "state")
     def _compute_is_invoiceable(self):
@@ -94,6 +91,11 @@ class LogisticsSchedule(models.Model):
                 "is_finished": False
             })
         return to_cancel
+    
+    def _action_sched_finished(self):
+        to_sched_finished = super()._action_sched_finished()
+        to_sched_finished._onchange_schedule_finished()
+        return to_sched_finished
     
     # def is_invoiceable(self):
     #     return not any(

--- a/logistics_planning_mgmt_weight/__manifest__.py
+++ b/logistics_planning_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.2.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_mgmt_weight/__manifest__.py
+++ b/logistics_planning_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.2.0',
+    'version': '13.0.1.3.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_mgmt_weight/i18n/es.po
+++ b/logistics_planning_mgmt_weight/i18n/es.po
@@ -6,14 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-21 17:53+0000\n"
-"PO-Revision-Date: 2024-03-21 17:53+0000\n"
+"POT-Creation-Date: 2024-05-27 15:35+0000\n"
+"PO-Revision-Date: 2024-05-27 17:35+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields,help:logistics_planning_mgmt_weight.field_stock_move__aux_picking_partner_id
@@ -58,6 +60,11 @@ msgstr "Crear ticket"
 #: model:ir.model.fields.selection,name:logistics_planning_mgmt_weight.selection__vehicle_type__ls_sale_transport_type__ground
 msgid "Ground"
 msgstr "Terrestre"
+
+#. module: logistics_planning_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:logistics_planning_mgmt_weight.logistics_schedule_input_view_tree_mgmt_weight
+msgid "Mark schedule as finished"
+msgstr "Marcar la planificación como finalizada"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields.selection,name:logistics_planning_mgmt_weight.selection__vehicle_type__ls_sale_transport_type__ocean-going
@@ -106,7 +113,7 @@ msgstr "Cond. suministro"
 #. module: logistics_planning_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:logistics_planning_mgmt_weight.logistics_schedule_input_view_tree
 msgid "Ticket"
-msgstr "Ticket"
+msgstr ""
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields,field_description:logistics_planning_mgmt_weight.field_stock_move__aux_picking_partner_id

--- a/logistics_planning_mgmt_weight/i18n/es.po
+++ b/logistics_planning_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-27 15:35+0000\n"
-"PO-Revision-Date: 2024-05-27 17:35+0200\n"
+"POT-Creation-Date: 2024-05-28 15:18+0000\n"
+"PO-Revision-Date: 2024-05-29 08:50+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -28,7 +28,8 @@ msgid ""
 "        "
 msgstr ""
 "\n"
-"        Campo técnico usado como workaround cuando se necesita rellenar previamente\n"
+"        Campo técnico usado como workaround cuando se necesita rellenar "
+"previamente\n"
 "        desde una acción picking_parter_id con el default_.\n"
 "        Esto ocurre cuando queremos crear un nuevo ticket desde una\n"
 "        planificación logística como borrador\n"
@@ -45,11 +46,22 @@ msgid ""
 "        "
 msgstr ""
 "\n"
-"        Campo técnico usado como workaround cuando se necesita rellenar previamente\n"
+"        Campo técnico usado como workaround cuando se necesita rellenar "
+"previamente\n"
 "        desde una acción picking_vehicle_id con el default_.\n"
 "        Esto ocurre cuando queremos crear un nuevo ticket desde una\n"
 "        planificación logística como borrador\n"
 "        "
+
+#. module: logistics_planning_mgmt_weight
+#: code:addons/logistics_planning_mgmt_weight/models/logistics_schedule.py:0
+#, python-format
+msgid ""
+"Cannot remove ticket from schedule, because it has extra tickets already "
+"linked. Please remove them first"
+msgstr ""
+"No se puede eliminar el ticket de la planificación porque tiene tickets "
+"extra ya enlazados. Por favor, elimine estos primero"
 
 #. module: logistics_planning_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:logistics_planning_mgmt_weight.logistics_schedule_input_view_tree_mgmt_weight
@@ -70,6 +82,23 @@ msgstr "Marcar la planificación como finalizada"
 #: model:ir.model.fields.selection,name:logistics_planning_mgmt_weight.selection__vehicle_type__ls_sale_transport_type__ocean-going
 msgid "Ocean-Going"
 msgstr "Marítimo"
+
+#. module: logistics_planning_mgmt_weight
+#: code:addons/logistics_planning_mgmt_weight/models/logistics_schedule.py:0
+#, python-format
+msgid ""
+"One or more of the selected schedules cannot be marked as finished because "
+"one of their tickets are still uncomplete (without net weight). Please "
+"check them"
+msgstr ""
+"No se puede marcar como finalizada una o más de las planificaciones "
+"seleccionadas porque uno de sus tickets relacionados está todavía "
+"incompleto (sin peso neto). Por favor, revíselos"
+
+#. module: logistics_planning_mgmt_weight
+#: model:ir.model.fields,field_description:logistics_planning_mgmt_weight.field_logistics_schedule__extra_stock_move_ids
+msgid "Other tickets"
+msgstr "Otros tickets"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.actions.act_window,name:logistics_planning_mgmt_weight.action_logistics_schedule_input_mgmt_weight
@@ -113,7 +142,7 @@ msgstr "Cond. suministro"
 #. module: logistics_planning_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:logistics_planning_mgmt_weight.logistics_schedule_input_view_tree
 msgid "Ticket"
-msgstr ""
+msgstr "Ticket"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields,field_description:logistics_planning_mgmt_weight.field_stock_move__aux_picking_partner_id

--- a/logistics_planning_mgmt_weight/i18n/logistics_planning_mgmt_weight.pot
+++ b/logistics_planning_mgmt_weight/i18n/logistics_planning_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-21 17:53+0000\n"
-"PO-Revision-Date: 2024-03-21 17:53+0000\n"
+"POT-Creation-Date: 2024-05-27 15:34+0000\n"
+"PO-Revision-Date: 2024-05-27 15:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -45,6 +45,11 @@ msgstr ""
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields.selection,name:logistics_planning_mgmt_weight.selection__vehicle_type__ls_sale_transport_type__ground
 msgid "Ground"
+msgstr ""
+
+#. module: logistics_planning_mgmt_weight
+#: model_terms:ir.ui.view,arch_db:logistics_planning_mgmt_weight.logistics_schedule_input_view_tree_mgmt_weight
+msgid "Mark schedule as finished"
 msgstr ""
 
 #. module: logistics_planning_mgmt_weight

--- a/logistics_planning_mgmt_weight/i18n/logistics_planning_mgmt_weight.pot
+++ b/logistics_planning_mgmt_weight/i18n/logistics_planning_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-27 15:34+0000\n"
-"PO-Revision-Date: 2024-05-27 15:34+0000\n"
+"POT-Creation-Date: 2024-05-28 15:18+0000\n"
+"PO-Revision-Date: 2024-05-28 15:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -38,6 +38,14 @@ msgid ""
 msgstr ""
 
 #. module: logistics_planning_mgmt_weight
+#: code:addons/logistics_planning_mgmt_weight/models/logistics_schedule.py:0
+#, python-format
+msgid ""
+"Cannot remove ticket from schedule, because it has extra tickets already "
+"linked. Please remove them first"
+msgstr ""
+
+#. module: logistics_planning_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:logistics_planning_mgmt_weight.logistics_schedule_input_view_tree_mgmt_weight
 msgid "Create ticket"
 msgstr ""
@@ -55,6 +63,20 @@ msgstr ""
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields.selection,name:logistics_planning_mgmt_weight.selection__vehicle_type__ls_sale_transport_type__ocean-going
 msgid "Ocean-Going"
+msgstr ""
+
+#. module: logistics_planning_mgmt_weight
+#: code:addons/logistics_planning_mgmt_weight/models/logistics_schedule.py:0
+#, python-format
+msgid ""
+"One or more of the selected schedules cannot be marked as finished because "
+"one of their tickets are still uncomplete (without net weight). Please check"
+" them"
+msgstr ""
+
+#. module: logistics_planning_mgmt_weight
+#: model:ir.model.fields,field_description:logistics_planning_mgmt_weight.field_logistics_schedule__extra_stock_move_ids
+msgid "Other tickets"
 msgstr ""
 
 #. module: logistics_planning_mgmt_weight

--- a/logistics_planning_mgmt_weight/models/logistics_schedule.py
+++ b/logistics_planning_mgmt_weight/models/logistics_schedule.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 import ast
 
@@ -15,12 +16,23 @@ class LogisticsSchedule(models.Model):
         states={"draft": [("readonly", False)]},
         copy=False,
     )
+    extra_stock_move_ids = fields.Many2many(
+        comodel_name="stock.move",
+        states={
+            "draft": [("readonly", True)],
+            "cancel": [("readonly", True)],
+            "done": [("readonly", True)],
+        },
+        string="Other tickets",
+    )
 
-    @api.depends("stock_move_id.net_weight")
+    @api.depends("stock_move_id.net_weight", "extra_stock_move_ids.net_weight")
     def _compute_product_uom_qty(self):
         super()._compute_product_uom_qty()
         for record in self.filtered(lambda x: x.stock_move_id.net_weight > 0.0):
-            record.product_uom_qty = record.stock_move_id.net_weight
+            record.product_uom_qty = sum(
+                (record.stock_move_id | record.extra_stock_move_ids).mapped("net_weight")
+            )
 
     @api.onchange("stock_move_id")
     def _onchange_stock_move_id(self):
@@ -30,7 +42,12 @@ class LogisticsSchedule(models.Model):
         sm_sudo = self.sudo().stock_move_id
         if not sm_sudo:
             # TODO clean some values?
-            pass
+            if self.extra_stock_move_ids:
+                raise UserError(_(
+                    "Cannot remove ticket from schedule, because it has extra"
+                    " tickets already linked. Please remove them first"
+                )
+            )
         elif self.sale_order_line_id or sm_sudo.picking_code == "internal":
             # Output from a sales order or internal transfer (for manual outputs)
             upd_values.update({
@@ -89,3 +106,36 @@ class LogisticsSchedule(models.Model):
     def action_logistics_schedule_finish(self):
         # TODO confirm wizard?
         self._action_sched_finished()
+
+    def _check_safe_finished(self):
+        super()._check_safe_finished()
+        wrong_finished = self.filtered(
+            lambda x: (
+                x.type == "input" and (
+                    len((x.stock_move_id | x.extra_stock_move_ids).filtered(lambda x: x.net_weight <= 0.0)) > 0
+                )
+            )
+        )
+        if wrong_finished:
+            raise UserError(
+                _(
+                    "One or more of the selected schedules cannot be marked as"
+                    " finished because one of their tickets are still"
+                    " uncomplete (without net weight). Please check them"
+                )
+            )
+
+    def write(self, values):
+        check_extra_moves = ("extra_stock_move_ids" in values)
+        if check_extra_moves:
+            # We assume that only a record is selected, no "expected singleton" should be fired
+            old_extra_stock_move_ids = self.extra_stock_move_ids
+        ret = super().write(values)
+        if check_extra_moves:
+            (self.extra_stock_move_ids - old_extra_stock_move_ids).write({
+                "logistics_schedule_id": self.id,
+            })
+            (old_extra_stock_move_ids - self.extra_stock_move_ids).write({
+                "logistics_schedule_id": False,
+            })
+        return ret

--- a/logistics_planning_mgmt_weight/models/logistics_schedule.py
+++ b/logistics_planning_mgmt_weight/models/logistics_schedule.py
@@ -24,7 +24,8 @@ class LogisticsSchedule(models.Model):
 
     @api.onchange("stock_move_id")
     def _onchange_stock_move_id(self):
-        super()._onchange_stock_move_id()
+        self_ctx = self.with_context(sched_finish_input_auto=False)
+        super(LogisticsSchedule, self_ctx)._onchange_stock_move_id()
         upd_values = {}
         sm_sudo = self.sudo().stock_move_id
         if not sm_sudo:
@@ -84,3 +85,7 @@ class LogisticsSchedule(models.Model):
         result["views"] = form_view
 
         return result
+    
+    def action_logistics_schedule_finish(self):
+        # TODO confirm wizard?
+        self._action_sched_finished()

--- a/logistics_planning_mgmt_weight/models/stock_move.py
+++ b/logistics_planning_mgmt_weight/models/stock_move.py
@@ -56,6 +56,10 @@ class StockMove(models.Model):
         res = super().create(values)
         if res.logistics_schedule_id:
             ls = res.logistics_schedule_id.sudo()
-            ls.stock_move_id = res.id
-            ls._onchange_stock_move_id()
+            if not ls.stock_move_id:
+                ls.stock_move_id = res.id
+                ls._onchange_stock_move_id()
+            else:
+                #ls.extra_stock_move_ids = [(4, res.id)]
+                ls.extra_stock_move_ids += res
         return res

--- a/logistics_planning_mgmt_weight/views/logistics_schedule_menu.xml
+++ b/logistics_planning_mgmt_weight/views/logistics_schedule_menu.xml
@@ -14,7 +14,7 @@
         />
         <field name="domain">[
             ("type", "=", "input"),
-            ('stock_move_id', '=', False),
+            ('schedule_finished', '=', False),
         ]</field>
         <field name="context">{"logistics_schedule_view": True, "search_default_pending": 1}</field>
     </record>

--- a/logistics_planning_mgmt_weight/views/logistics_schedule_views.xml
+++ b/logistics_planning_mgmt_weight/views/logistics_schedule_views.xml
@@ -121,12 +121,21 @@
                 name="action_logistics_schedule_form_view"
                 position="after"
             >
+
                 <button
                     name="action_logistics_schedule_create_input_ticket"
                     icon="fa-ticket"
                     class="p-0"
                     type="object"
                     title="Create ticket"
+                />                
+                <button
+                    name="action_logistics_schedule_finish"
+                    icon="fa-sign-out"
+                    class="p-0"
+                    type="object"
+                    title="Mark schedule as finished"
+                    attrs="{'invisible': [('product_uom_qty', '&lt;=', 0.0)]}"
                 />                
             </button>
             <button
@@ -135,6 +144,12 @@
             >
                 <attribute name="invisible">1</attribute>
             </button>
+            <field
+                name="schedule_finished"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </field>
         </field>
     </record>
 </odoo>

--- a/logistics_planning_mgmt_weight/views/logistics_schedule_views.xml
+++ b/logistics_planning_mgmt_weight/views/logistics_schedule_views.xml
@@ -41,13 +41,36 @@
                     join_operator="OR"
                 >[
                     ('picking_partner_id', '=', partner_id),
-                    ('product_id', '=', product_id),
                     ('state', 'in', ['draft', 'cancel']),
                     ('logistics_schedule_id', '=', False),
                     ('logistics_schedule_disabled', '=', False),
                     ('picking_code', '=', 'incoming'),
                     ('net_weight', '&gt;', 0),
                 ]</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="logistics_schedule_input_view_form" model="ir.ui.view">
+        <field name="name">logistics.schedule.form input (in logistics_planning_mgmt_weight)</field>
+        <field name="model">logistics.schedule</field>
+        <field name="inherit_id" ref="logistics_planning_base.logistics_schedule_input_view_form"/>
+        <field name="arch" type="xml">
+            <field name="stock_move_id" position="after">
+                <field
+                    name="extra_stock_move_ids"
+                    domain="[
+                        ('picking_partner_id', '=', partner_id),
+                        ('state', 'in', ['draft', 'cancel']),
+                        ('logistics_schedule_id', '=', False),
+                        ('logistics_schedule_disabled', '=', False),
+                        ('picking_code', '=', 'incoming'),
+                        ('net_weight', '&gt;', 0),
+                    ]"
+                    context="{'logistics_schedule_view': True}"
+                    attrs="{'readonly': [('stock_move_id', '=', False)]}"
+                    options="{'no_create_edit': True, 'no_create': True}"
+                    widget="many2many_tags"
+                />
             </field>
         </field>
     </record>
@@ -70,7 +93,7 @@
             <field name="stock_move_id" position="attributes">
                 <!--
                         same partner
-                        same product
+                        same product => REMOVED since schedules could be created for a generic product
                         tickets pending to be classified or already classified
                         still unassigned and available
                         only input tickets
@@ -84,7 +107,6 @@
                     join_operator="OR"
                 >[
                     ('picking_partner_id', '=', partner_id),
-                    ('product_id', '=', product_id),
                     ('state', 'in', ['draft', 'cancel']),
                     ('logistics_schedule_id', '=', False),
                     ('logistics_schedule_disabled', '=', False),
@@ -106,6 +128,24 @@
             <xpath expr="//field[@name='stock_move_id']" position="attributes">
                 <attribute name="string">Ticket</attribute>
             </xpath>
+            <field name="stock_move_id" position="after">
+                <field
+                    name="extra_stock_move_ids"
+                    domain="[
+                        ('picking_partner_id', '=', partner_id),
+                        ('state', 'in', ['draft', 'cancel']),
+                        ('logistics_schedule_id', '=', False),
+                        ('logistics_schedule_disabled', '=', False),
+                        ('picking_code', '=', 'incoming'),
+                        ('net_weight', '&gt;', 0),
+                    ]"
+                    context="{'logistics_schedule_view': True}"
+                    attrs="{'readonly': [('stock_move_id', '=', False)]}"
+                    options="{'no_create_edit': True, 'no_create': True}"
+                    widget="many2many_tags"
+                    optional="show"
+                />
+            </field>
         </field>
     </record>
     <record id="logistics_schedule_input_view_tree_mgmt_weight" model="ir.ui.view">


### PR DESCRIPTION
_Manual mark as finished_
- With this improvement, new tools for massive schedules mark as finished are added.
- And, when `logistics_planning_mgmt_weight` is installed, schedule inputs are not automatically marked as finished when a ticket (move) is selected, so massive marking schedules as finished becomes important.

_Multi ticket_
- For inputs an "extra tickets" field is added, when more than one tickets need to be linked to a logistics schedule.
- For this new field and also existing ticket field, required product match between logistics schedule and ticket is no longer required.