### PR TITLE
[13.0][IMP] logistics_planning_[purchase|sale|mgmt_weight]: PO/SO and POL/SOL fields updated propagation to LSs support

### DIFF
--- a/logistics_planning_mgmt_weight/__manifest__.py
+++ b/logistics_planning_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.3.0',
+    'version': '13.0.1.4.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_mgmt_weight/__manifest__.py
+++ b/logistics_planning_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.4.0',
+    'version': '13.0.1.5.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_mgmt_weight/models/purchase_order_line.py
+++ b/logistics_planning_mgmt_weight/models/purchase_order_line.py
@@ -16,3 +16,10 @@ class PurchaseOrderLine(models.Model):
             "supply_condition_id": self.supply_condition_id.id or False,
         })
         return values
+
+    def _update_logistics_schedules_dict(self):
+        ret = super()._update_logistics_schedules_dict()
+        ret.update({
+            "supply_condition_id": "supply_condition_id",
+        })
+        return ret

--- a/logistics_planning_mgmt_weight/models/sale_order_line.py
+++ b/logistics_planning_mgmt_weight/models/sale_order_line.py
@@ -18,3 +18,10 @@ class SaleOrderLine(models.Model):
             "supply_condition_id": self.supply_condition_id.id or False,
         })
         return values
+
+    def _update_logistics_schedules_dict(self):
+        ret = super()._update_logistics_schedules_dict()
+        ret.update({
+            "supply_condition_id": "supply_condition_id",
+        })
+        return ret

--- a/logistics_planning_purchase/__manifest__.py
+++ b/logistics_planning_purchase/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.2.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_purchase/models/purchase_order.py
+++ b/logistics_planning_purchase/models/purchase_order.py
@@ -112,3 +112,30 @@ class PurchaseOrder(models.Model):
             ls_ids = self.env["logistics.schedule"].sudo().create(ls_values)
             ls_ids._action_ready()
         return res
+
+    def write(self, values):
+        ret = super().write(values)
+        self._update_logistics_schedules(values)
+        return ret
+
+    def _update_logistics_schedules(self, values):
+        """
+        We add here those purchase order values that should be hardlinked
+        to logistics schedules
+        """
+        ls_ids = self.sudo().logistics_schedule_ids.filtered(
+            lambda x: x.state not in ["done", "cancel"]
+        )
+        if ls_ids:
+            upd_values = {}
+            if "picking_type_id" in values:
+                upd_values[
+                    "destination_partner_id"
+                ] = self.picking_type_id.warehouse_id.partner_id.id
+            if "incoterm_id" in values:
+                upd_values.update({
+                    "incoterm_id": self.incoterm_id.id,
+                    "transport_type": self.ls_transport_type,
+                })
+            if upd_values:
+                ls_ids.write(upd_values)

--- a/logistics_planning_purchase/models/purchase_order_line.py
+++ b/logistics_planning_purchase/models/purchase_order_line.py
@@ -1,7 +1,7 @@
 # © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 from odoo.addons.logistics_planning_base.models.logistics_schedule import (
     PRICE_UNIT_TYPES,
@@ -86,13 +86,34 @@ class PurchaseOrderLine(models.Model):
         }
     
     def write(self, values):
+        ret = super().write(values)
+        self._update_logistics_schedules(values)
+        return ret
+
+    def _update_logistics_schedules(self, values):
         """
         We add here those purchase line values that should be hardlinked
         to logistics schedules
         """
-        ret = super().write(values)
-        if "date_planned" in values:
-            self.sudo().logistics_schedule_ids.filtered(
-                lambda x: x.state not in ["done", "cancel"]
-            ).write({"scheduled_load_date": values["date_planned"]})
-        return ret
+        ls_ids = self.sudo().logistics_schedule_ids.filtered(
+            lambda x: x.state not in ["done", "cancel"]
+        )
+        if ls_ids:
+            upd_fields = self._update_logistics_schedules_dict()
+            upd_values = {
+                upd_fields[key]: values[key]
+                for key in dict(filter(lambda x: x[0] in values, upd_fields.items()))
+            }
+            if upd_values:
+                ls_ids.write(upd_values)
+
+    @api.model
+    def _update_logistics_schedules_dict(self):        
+        return {
+            "partner_id": "partner_id",
+            "product_id": "product_id",
+            "product_uom": "product_uom",
+            "date_planned": "scheduled_load_date",
+            "logistics_price_unit_type": "logistics_price_unit_type",
+            "logistics_price_unit": "logistics_price_unit",
+        }

--- a/logistics_planning_sale/__manifest__.py
+++ b/logistics_planning_sale/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.4.0',
+    'version': '13.0.1.5.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_sale/models/sale_order.py
+++ b/logistics_planning_sale/models/sale_order.py
@@ -106,3 +106,29 @@ class SaleOrder(models.Model):
                 ls_ids = self.env["logistics.schedule"].sudo().create(ls_values)
                 ls_ids._action_ready()
         return res
+
+    def write(self, values):
+        ret = super().write(values)
+        self._update_logistics_schedules(values)
+        return ret
+
+    def _update_logistics_schedules(self, values):
+        """
+        We add here those sale order values that should be hardlinked
+        to logistics schedules
+        """
+        ls_ids = self.sudo().logistics_schedule_ids.filtered(
+            lambda x: x.state not in ["done", "cancel"]
+        )
+        if ls_ids:
+            upd_values = {}
+            if "warehouse_id" in values:
+                upd_values[
+                    "destination_partner_id"
+                ] = self.warehouse_id.partner_id.id
+            if "partner_shipping_id" in values:
+                upd_values["partner_id"] = self.partner_shipping_id.id
+            if "incoterm" in values:
+                upd_values["incoterm_id"] = self.incoterm.id
+            if upd_values:
+                ls_ids.write(upd_values)

--- a/logistics_planning_sale/models/sale_order_line.py
+++ b/logistics_planning_sale/models/sale_order_line.py
@@ -1,7 +1,7 @@
 # © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 from odoo.addons.logistics_planning_base.models.logistics_schedule import (
     PRICE_UNIT_TYPES,
@@ -92,15 +92,34 @@ class SaleOrderLine(models.Model):
         }
 
     def write(self, values):
+        ret = super().write(values)
+        self._update_logistics_schedules(values)
+        return ret
+
+    def _update_logistics_schedules(self, values):
         """
         We add here those sale line values that should be hardlinked
         to logistics schedules
         """
-        ret = super().write(values)
-        # This value is already added by sale_order_line_date, but this
-        #  code make our addon actually independent on it
-        if "commitment_date" in values:
-            self.sudo().logistics_schedule_ids.filtered(
-                lambda x: x.state not in ["done", "cancel"]
-            ).write({"scheduled_load_date": values["commitment_date"]})
-        return ret
+        ls_ids = self.sudo().logistics_schedule_ids.filtered(
+            lambda x: x.state not in ["done", "cancel"]
+        )
+        if ls_ids:
+            upd_fields = self._update_logistics_schedules_dict()
+            upd_values = {
+                upd_fields[key]: values[key]
+                for key in dict(filter(lambda x: x[0] in values, upd_fields.items()))
+            }
+            if upd_values:
+                ls_ids.write(upd_values)
+
+    @api.model
+    def _update_logistics_schedules_dict(self):        
+        return {
+            "product_id": "product_id",
+            "product_uom": "product_uom",
+            "commitment_date": "scheduled_load_date",
+            "logistics_price_unit_type": "logistics_price_unit_type",
+            "logistics_price_unit": "logistics_price_unit",
+            "ls_transport_type": "transport_type",
+        }


### PR DESCRIPTION
With this improvement, those logistics schedules fields that come from purchase/sale order and/or purchase/sale line are automatically updated when origin fields are updated.