### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: ticket creation - use net date for numbering - default case

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.24.2",
+    "version": "13.0.1.24.3",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/stock_move.py
+++ b/stock_picking_mgmt_weight/models/stock_move.py
@@ -181,6 +181,8 @@ class StockMovFrontend(models.Model):
                 values.get("date_gross_weight", False)
                 or
                 values.get("date_tare", False)
+                or
+                fields.Datetime.now()
             )
             new_picking = self.env["stock.picking"].new({
                 "partner_id": values["picking_partner_id"],


### PR DESCRIPTION
When a ticket is created without filling any weight (and dates), no date is selected for ticket number determination, and an error is raised. This is the usual case when e.g. "capture gross" button is clicked during ticket creation (not manual creation).
This fix was introduced by #77.

cc @ChristianSantamaria already in Production, directly merged