### PR TITLE
[13.0][FIX] logistics_planning_*: write() -> update() calls in onchange methods

### DIFF
--- a/logistics_planning_base/__manifest__.py
+++ b/logistics_planning_base/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.2.0',
+    'version': '13.0.1.2.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': ["stock", "base_view_inheritance_extension"],

--- a/logistics_planning_base/models/logistics_schedule.py
+++ b/logistics_planning_base/models/logistics_schedule.py
@@ -163,7 +163,7 @@ class LogisticsSchedule(models.Model):
                 or self.env.context.get("sched_finish_input_auto", True)
             )
             date_field = "commitment_date" if self.type == 'output' else "effective_date"
-            self.write({
+            self.update({
                 date_field: self.stock_move_id.date,
                 "schedule_finished": sched_finish,
             }) 

--- a/logistics_planning_invoicing/__manifest__.py
+++ b/logistics_planning_invoicing/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.1.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': [

--- a/logistics_planning_invoicing/models/logistics_schedule.py
+++ b/logistics_planning_invoicing/models/logistics_schedule.py
@@ -47,7 +47,7 @@ class LogisticsSchedule(models.Model):
     def _onchange_schedule_finished(self):
         self.filtered(
             lambda x: x.schedule_finished and x.incoterm_id.ls_invoice_disabled
-        ).write({"is_finished": True})
+        ).update({"is_finished": True})
 
     @api.depends("account_move_line_id", "state")
     def _compute_is_invoiceable(self):

--- a/logistics_planning_mgmt_weight/__manifest__.py
+++ b/logistics_planning_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.5.0',
+    'version': '13.0.1.5.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_mgmt_weight/models/logistics_schedule.py
+++ b/logistics_planning_mgmt_weight/models/logistics_schedule.py
@@ -66,7 +66,7 @@ class LogisticsSchedule(models.Model):
             })
 
         if upd_values:
-            self.write(upd_values)
+            self.update(upd_values)
 
     def _action_ready_fields_check_req_fields(self):
         fields = super()._action_ready_fields_check_req_fields()


### PR DESCRIPTION
Some `onchange` methods had `write()` calls within, that could lead to unexpected results. In that cases we should use dot (".") notation or `update()` calls.

cc @ChristianSantamaria already tested in AluTest by me... I'll put it right now in AluProd environment