### PR TITLE
[13.0][FIX] logistics_planning_sale: linking internal stock moves doesn't work

### DIFF
--- a/logistics_planning_sale/__manifest__.py
+++ b/logistics_planning_sale/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.5.0',
+    'version': '13.0.1.5.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_sale/migrations/13.0.1.5.1/pre-migration.py
+++ b/logistics_planning_sale/migrations/13.0.1.5.1/pre-migration.py
@@ -1,0 +1,33 @@
+# © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(
+        env.cr, "stock_move", "rel_sale_order_id"
+    ):
+        openupgrade.logged_query(
+            env.cr,
+            """ALTER TABLE stock_move
+            ADD COLUMN rel_sale_order_id int;
+            COMMENT ON COLUMN stock_move.rel_sale_order_id IS 'Related Sale Order';
+            """,
+        )
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE
+                stock_move
+            SET
+                rel_sale_order_id=sol.order_id
+            FROM
+                stock_move sm
+            INNER JOIN
+                sale_order_line sol on sol.id=sm.sale_line_id
+            WHERE
+                stock_move.id=sm.id
+            """,
+        )

--- a/logistics_planning_sale/models/stock_move.py
+++ b/logistics_planning_sale/models/stock_move.py
@@ -13,9 +13,9 @@ class StockMove(models.Model):
         string="Sale order - logistics schedule generation disabled",
     )
 
-    # TODO make it stored if becomes slow
     rel_sale_order_id = fields.Many2one(
         related="sale_line_id.order_id",
+        store=True,
         string="Related Sale Order",
         help="""
         Technical field used for logistics schedule stock move view domain


### PR DESCRIPTION
When added #122 for a soft SO stock move links, internal transfers couldn't be linked any more. This was caused because a `.xml` domain to a related field when desired value is `False` won't work. Making `rel_sale_order_id` field stored fixes it.