### PR TITLE
[13.0][IMP] logistics_planning_base: allow changing partner for manual schedules

### DIFF
--- a/logistics_planning_base/__manifest__.py
+++ b/logistics_planning_base/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.3.0',
+    'version': '13.0.1.4.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': ["stock", "base_view_inheritance_extension"],

--- a/logistics_planning_base/i18n/es.po
+++ b/logistics_planning_base/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-21 10:15+0000\n"
-"PO-Revision-Date: 2024-06-21 12:17+0200\n"
+"POT-Creation-Date: 2024-06-24 15:34+0000\n"
+"PO-Revision-Date: 2024-06-24 17:36+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -41,6 +41,19 @@ msgstr ""
 "        Campo técnico da acceso al contacto asociado al almacén de la ubicación\n"
 "        origen de este movimiento.\n"
 "        Solo se calcula para traspasos internos.\n"
+"        "
+
+#. module: logistics_planning_base
+#: model:ir.model.fields,help:logistics_planning_base.field_logistics_schedule__partner_readonly
+msgid ""
+"\n"
+"        Technical field that helps us determining whether a partner can be\n"
+"        modified by users, only for 'ready' state\n"
+"        "
+msgstr ""
+"\n"
+"        Campo técnico que nos ayuda a determinar cuándo podrán cambiar\n"
+"        modificar, en el estado 'en curso', el contacto los usuarios\n"
 "        "
 
 #. module: logistics_planning_base
@@ -270,6 +283,11 @@ msgstr "Entrada"
 #: model:ir.ui.menu,name:logistics_planning_base.menu_input
 msgid "Inputs"
 msgstr "Entradas"
+
+#. module: logistics_planning_base
+#: model:ir.model.fields,field_description:logistics_planning_base.field_logistics_schedule__partner_readonly
+msgid "Is partner readonly"
+msgstr "El contacto es de solo lectura"
 
 #. module: logistics_planning_base
 #: model_terms:ir.ui.view,arch_db:logistics_planning_base.logistics_schedule_view_tree

--- a/logistics_planning_base/i18n/logistics_planning_base.pot
+++ b/logistics_planning_base/i18n/logistics_planning_base.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-21 10:14+0000\n"
-"PO-Revision-Date: 2024-06-21 10:14+0000\n"
+"POT-Creation-Date: 2024-06-24 15:33+0000\n"
+"PO-Revision-Date: 2024-06-24 15:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -30,6 +30,15 @@ msgid ""
 "        Technical field enables us accessing partner for the origin location\n"
 "        warehouse for this move.\n"
 "        We'll only calculate it for internal transfers.\n"
+"        "
+msgstr ""
+
+#. module: logistics_planning_base
+#: model:ir.model.fields,help:logistics_planning_base.field_logistics_schedule__partner_readonly
+msgid ""
+"\n"
+"        Technical field that helps us determining whether a partner can be\n"
+"        modified by users, only for 'ready' state\n"
 "        "
 msgstr ""
 
@@ -253,6 +262,11 @@ msgstr ""
 #. module: logistics_planning_base
 #: model:ir.ui.menu,name:logistics_planning_base.menu_input
 msgid "Inputs"
+msgstr ""
+
+#. module: logistics_planning_base
+#: model:ir.model.fields,field_description:logistics_planning_base.field_logistics_schedule__partner_readonly
+msgid "Is partner readonly"
 msgstr ""
 
 #. module: logistics_planning_base

--- a/logistics_planning_base/models/logistics_schedule.py
+++ b/logistics_planning_base/models/logistics_schedule.py
@@ -78,7 +78,7 @@ class LogisticsSchedule(models.Model):
         string="Destination",
         states=READONLY3_STATES,
     )
-    partner_id = fields.Many2one('res.partner', states=READONLY1_STATES)
+    partner_id = fields.Many2one('res.partner', states=READONLY3_STATES)
     transport_type = fields.Selection(
         selection=TRANSPORT_TYPE,
         states=READONLY1_STATES,
@@ -143,6 +143,14 @@ class LogisticsSchedule(models.Model):
     schedule_finished = fields.Boolean(states=READONLY2_STATES, copy=False)
     note = fields.Text(copy=False)
 
+    partner_readonly = fields.Boolean(
+        compute="_compute_partner_readonly",
+        string="Is partner readonly",
+        help="""
+        Technical field that helps us determining whether a partner can be
+        modified by users, only for 'ready' state
+        """,
+    )
     can_set_to_done = fields.Boolean(
         compute="_compute_can_set_to_done",
         help="""
@@ -159,6 +167,30 @@ class LogisticsSchedule(models.Model):
         to_done = self.filtered(lambda x: x.state == "ready")
         to_done.write({"can_set_to_done": True})
         (self - to_done).write({"can_set_to_done": False})
+
+    def _compute_partner_readonly(self):
+        """
+        By field definition, when schedule is in 'done' or 'cancel' state
+        partner cannot be editable by users.
+        This method aims to only check 'ready' state exceptions.
+        An instrumental field is defined instead of simply creating a XML
+        domain, so it could be later improved when needed
+        """
+        editable_ls_ids = self.filtered(lambda x: (
+            not x.origin and not x.stock_move_id
+        ))
+        editable_ls_ids.write({"partner_readonly": False})
+        (self - editable_ls_ids).write({"partner_readonly": True})
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        """
+        For corner case when adding stock move for manual schedules,
+        and then trying to remove partner, before saving (after saving
+        partner becomes readonly and that situation is not possible)
+        """
+        if not self.partner_id:
+            self.stock_move_id = False
 
     @api.onchange("product_id")
     def _onchange_product_id(self):

--- a/logistics_planning_base/views/logistics_schedule_views.xml
+++ b/logistics_planning_base/views/logistics_schedule_views.xml
@@ -66,7 +66,12 @@
                 />
                 <field name="origin" optional="show" />
                 <field name="destination_partner_id" optional="show" />                
-                <field name="partner_id" optional="show" />
+                <field name="partner_readonly" invisible="1" />
+                <field
+                    name="partner_id"
+                    optional="show"
+                    attrs="{'readonly': [('partner_readonly', '=', True)]}"
+                />
                 <field
                     name="stock_move_id"
                     domain="[
@@ -290,7 +295,11 @@
                                 context="{'logistics_schedule_view': True}"
                                 options="{'no_create_edit': True, 'no_create': True}"
                             />
-                            <field name="partner_id" />
+                            <field name="partner_readonly" invisible="1" />
+                            <field
+                                name="partner_id"
+                                attrs="{'readonly': [('partner_readonly', '=', True)]}"
+                            />
                             <field name="destination_partner_id" />
                         </group>
                         <group>


### PR DESCRIPTION
This is allowed for manual schedules at `ready` state. An extra code that prevents saving a schedule with move but without partner is added