### PR TITLE
[13.0][FIX] logistics_planning_base: partner readonly check fails for readonly users

### DIFF
--- a/logistics_planning_base/__manifest__.py
+++ b/logistics_planning_base/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.5.0',
+    'version': '13.0.1.5.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': ["stock", "base_view_inheritance_extension"],

--- a/logistics_planning_base/models/logistics_schedule.py
+++ b/logistics_planning_base/models/logistics_schedule.py
@@ -145,6 +145,7 @@ class LogisticsSchedule(models.Model):
 
     partner_readonly = fields.Boolean(
         compute="_compute_partner_readonly",
+        compute_sudo=True,
         string="Is partner readonly",
         help="""
         Technical field that helps us determining whether a partner can be


### PR DESCRIPTION
If a user that have read-only access to logistics schedules loads any view that computes `partner_readonly` technical field, an error is raised.

Addon `logistics_planning_mgmt_weight` adds a menu for this limited access users, so an error is raised. This fixes it.