### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: key fields without `copy=False`

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.25.0",
+    "version": "13.0.1.25.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/purchase_order.py
+++ b/stock_picking_mgmt_weight/models/purchase_order.py
@@ -17,6 +17,7 @@ class PurchaseOrder(models.Model):
     related_order_id = fields.Many2one(
         comodel_name="purchase.order",
         readonly=True,
+        copy=False,
     )
     related_order_ids = fields.Many2many(
         string="Related orders",
@@ -26,6 +27,7 @@ class PurchaseOrder(models.Model):
         column2="related_order_id",
         compute="_compute_related_order_ids",
         store=True,
+        copy=False,
     )
     related_order_count = fields.Integer(
         compute="_compute_related_order_ids",
@@ -39,6 +41,7 @@ class PurchaseOrder(models.Model):
         relation="purchase_order_related",
         column1="related_order_id",
         column2="order_id",
+        copy=False,
     )
     classification = fields.Boolean(
         compute="_compute_classification",

--- a/stock_picking_mgmt_weight/models/purchase_order_line.py
+++ b/stock_picking_mgmt_weight/models/purchase_order_line.py
@@ -10,6 +10,7 @@ class PurchaseOrderLine(models.Model):
 
     related_real_order_line_id = fields.Many2one(
         "purchase.order.line",
+        copy=False,
         help="For extra lines created in classification process, this field"
         " indicates the original linked line",
     )


### PR DESCRIPTION
With this fix incorrect links between classifications and original purchase orders are prevented when duplicating existing and completed purchase orders.