### PR TITLE
[13.0][IMP] logistics_planning_invoicing: grouping schedules in the same invoice line

### DIFF
--- a/logistics_planning_invoicing/__manifest__.py
+++ b/logistics_planning_invoicing/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.3.0',
+    'version': '13.0.2.0.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': [

--- a/logistics_planning_invoicing/i18n/es.po
+++ b/logistics_planning_invoicing/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-06 08:01+0000\n"
-"PO-Revision-Date: 2024-06-06 10:02+0200\n"
+"POT-Creation-Date: 2024-07-26 12:23+0000\n"
+"PO-Revision-Date: 2024-07-26 14:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -18,9 +18,25 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. module: logistics_planning_invoicing
+#: model:ir.model.fields,help:logistics_planning_invoicing.field_logistics_schedule_account_move_wizard__group_lines
+msgid ""
+"\n"
+"        When checked, created invoice lines will be made in aggregated mode\n"
+"        "
+msgstr ""
+"\n"
+"        Cuando está marcado, las líneas de factura se crearán de forma agrupada\n"
+"        "
+
+#. module: logistics_planning_invoicing
 #: model:ir.model.fields,field_description:logistics_planning_invoicing.field_logistics_schedule__account_move_line_id
 msgid "Account Move Line"
 msgstr "Lineas de factura"
+
+#. module: logistics_planning_invoicing
+#: model:ir.model.fields,field_description:logistics_planning_invoicing.field_account_move_line__agg_logistics_schedule_ids
+msgid "Aggregated logistics schedules"
+msgstr "Planificaciones logísticas agrupadas"
 
 #. module: logistics_planning_invoicing
 #: model:ir.model.fields,field_description:logistics_planning_invoicing.field_logistics_schedule_account_move_wizard__ref
@@ -116,6 +132,11 @@ msgstr "Nombre mostrado"
 #: model:ir.model.fields.selection,name:logistics_planning_invoicing.selection__account_incoterms__ls_sale_transport_type__ground
 msgid "Ground"
 msgstr "Terrestre"
+
+#. module: logistics_planning_invoicing
+#: model:ir.model.fields,field_description:logistics_planning_invoicing.field_logistics_schedule_account_move_wizard__group_lines
+msgid "Group Lines"
+msgstr "Agrupar líneas"
 
 #. module: logistics_planning_invoicing
 #: model:ir.model.fields,field_description:logistics_planning_invoicing.field_logistics_schedule_account_move_wizard__id

--- a/logistics_planning_invoicing/i18n/logistics_planning_invoicing.pot
+++ b/logistics_planning_invoicing/i18n/logistics_planning_invoicing.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-06 08:00+0000\n"
-"PO-Revision-Date: 2024-06-06 08:00+0000\n"
+"POT-Creation-Date: 2024-07-26 12:23+0000\n"
+"PO-Revision-Date: 2024-07-26 12:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,21 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: logistics_planning_invoicing
+#: model:ir.model.fields,help:logistics_planning_invoicing.field_logistics_schedule_account_move_wizard__group_lines
+msgid ""
+"\n"
+"        When checked, created invoice lines will be made in aggregated mode\n"
+"        "
+msgstr ""
+
+#. module: logistics_planning_invoicing
 #: model:ir.model.fields,field_description:logistics_planning_invoicing.field_logistics_schedule__account_move_line_id
 msgid "Account Move Line"
+msgstr ""
+
+#. module: logistics_planning_invoicing
+#: model:ir.model.fields,field_description:logistics_planning_invoicing.field_account_move_line__agg_logistics_schedule_ids
+msgid "Aggregated logistics schedules"
 msgstr ""
 
 #. module: logistics_planning_invoicing
@@ -113,6 +126,11 @@ msgstr ""
 #. module: logistics_planning_invoicing
 #: model:ir.model.fields.selection,name:logistics_planning_invoicing.selection__account_incoterms__ls_sale_transport_type__ground
 msgid "Ground"
+msgstr ""
+
+#. module: logistics_planning_invoicing
+#: model:ir.model.fields,field_description:logistics_planning_invoicing.field_logistics_schedule_account_move_wizard__group_lines
+msgid "Group Lines"
 msgstr ""
 
 #. module: logistics_planning_invoicing

--- a/logistics_planning_invoicing/models/account_move.py
+++ b/logistics_planning_invoicing/models/account_move.py
@@ -16,11 +16,11 @@ class AccountMove(models.Model):
 
     @api.onchange('logistics_schedule_ids')
     def _onchange_logistics_schedule_auto_complete(self):
-        # TODO invoice origin
         self.fiscal_position_id = self.partner_id.property_account_position_id
         new_lines = self.env['account.move.line']
-        for logistic_schedule in self.logistics_schedule_ids:
-            new_line = new_lines.new(logistic_schedule._prepare_ls_account_move_line(self))
+        aml_dict_list = self.logistics_schedule_ids._prepare_ls_account_move_lines(self)
+        for aml_dict in aml_dict_list:
+            new_line = new_lines.new(aml_dict)
             new_line.account_id = new_line._get_computed_account()
             taxes = new_line._get_computed_taxes()
             if taxes and self.fiscal_position_id:
@@ -48,11 +48,13 @@ class AccountMove(models.Model):
         return super().unlink()
 
     def _ls_secure_unlink(self):
-        aml_ids = self.invoice_line_ids.sudo().filtered(
-            lambda x: x.logistics_schedule_id
-        )
-        if aml_ids:
-            ls_ids = aml_ids.logistics_schedule_id
-            aml_ids.write({"logistics_schedule_id": False})
-            # TODO implement done->ready action method?
-            ls_ids.write({"state": "ready"})
+        ls_ids = self.invoice_line_ids.sudo()._get_all_logistics_schedule_ids()
+        if ls_ids:
+            ls_ids.account_move_line_id.write({
+                "logistics_schedule_id": False,
+                "agg_logistics_schedule_ids": False,
+            })
+            ls_ids.write({
+                "account_move_line_id": False,
+                "state": "ready",
+            })

--- a/logistics_planning_invoicing/models/account_move_line.py
+++ b/logistics_planning_invoicing/models/account_move_line.py
@@ -8,14 +8,27 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     logistics_schedule_id = fields.Many2one('logistics.schedule')
+    agg_logistics_schedule_ids = fields.Many2many(
+        comodel_name="logistics.schedule",
+        string="Aggregated logistics schedules",
+    )
+
+    def _get_all_logistics_schedule_ids(self):
+        return (
+            self.logistics_schedule_id
+            | self.agg_logistics_schedule_ids
+        )
 
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)
-        lines_w_ls = lines.filtered(lambda x: x.logistics_schedule_id) 
-        for line in lines_w_ls:
-            line.logistics_schedule_id.account_move_line_id = line.id
-        lines_w_ls.logistics_schedule_id._action_done()
+        for line in lines:
+            all_ls_ids = line._get_all_logistics_schedule_ids().sudo()
+            if all_ls_ids:
+                all_ls_ids.write({
+                    "account_move_line_id": line.id,
+                })
+                all_ls_ids._action_done()
         return lines
 
     def write(self, values):

--- a/logistics_planning_invoicing/models/logistics_schedule.py
+++ b/logistics_planning_invoicing/models/logistics_schedule.py
@@ -154,6 +154,65 @@ class LogisticsSchedule(models.Model):
             'default_logistics_schedule_ids': self.ids,
         }
 
+    def _prepare_ls_account_move_lines(self, move_id):
+        def make_key(ls):
+            prut = ls["logistics_price_unit_type"]
+            list_key = [
+                ls["product_id"],
+                ls.get("analytic_account_id", 0),
+                ls["product_uom_id"],
+                prut,
+                0.0 if prut == "trip" else ls["price_unit"],
+            ]
+            return tuple(list_key)
+
+        # Original prepare list that enable us to create one invoice line
+        #  per selected logistics schedule + extra useful information for
+        #  the case we need to group them
+        prepare_ls_list = [
+            ls._prepare_ls_account_move_line(move_id)
+            for ls in self
+        ]
+        if (
+            self.env.context.get("group_lines", False)
+            and len(prepare_ls_list) > 1
+        ):
+            """
+            Grouping criteria by:
+            - product (replacing account, that is not available at this point)
+            - analytic account
+            - product unit of measure
+            - price unit type
+            - (OPT) price unit
+
+            When aggregating,
+            - If product unit of mesure is 'trip' => adding to price unit
+            - If product unit of mesure is 'unit' => adding to price qty
+            """
+            prepare_ls_list_agg = {}
+            for prepare_ls in prepare_ls_list:
+                prepare_ls_agg = prepare_ls_list_agg.setdefault(make_key(prepare_ls), {})
+                if not prepare_ls_agg:
+                    prepare_ls_agg.update(prepare_ls)
+                else:
+                    if prepare_ls_agg["logistics_price_unit_type"] == "trip":
+                        prepare_ls_agg["price_unit"] += prepare_ls["price_unit"]
+                    else:
+                        prepare_ls_agg["quantity"] += prepare_ls["quantity"]
+                    # Second LS for this line, so we have to remove "Many2many", if existed
+                    old_ls_id = prepare_ls_agg.pop("logistics_schedule_id", False)
+                    ls_ids = prepare_ls_agg.setdefault("agg_logistics_schedule_ids", [])
+                    if old_ls_id:
+                        ls_ids.append((4, old_ls_id))
+                    ls_ids.append((4, prepare_ls["logistics_schedule_id"]))
+            prepare_ls_list = list(prepare_ls_list_agg.values())
+
+        # Before returning list, we should extract those values that won't
+        #  belong to an invoice line
+        for prepare_ls in prepare_ls_list:
+            prepare_ls.pop("logistics_price_unit_type")
+        return prepare_ls_list
+
     def _prepare_ls_account_move_line(self, move_id):
         self.ensure_one()
         ls_id = self.browse(self.id.origin)
@@ -173,6 +232,7 @@ class LogisticsSchedule(models.Model):
             'price_unit': ls_id.logistics_price_unit_done,
             'quantity': qty,
             'partner_id': ls_id.partner_id.id,
+            "logistics_price_unit_type": ls_id.logistics_price_unit_type,
         }
 
     def _get_invoice_product(self):

--- a/logistics_planning_invoicing/views/account_move_views.xml
+++ b/logistics_planning_invoicing/views/account_move_views.xml
@@ -25,9 +25,18 @@
             </xpath>
             <xpath expr="//field[@name='line_ids']/tree/field[@name='name']" position="after">
                 <field name="logistics_schedule_id" optional="hide"/>
+                <field
+                    name="agg_logistics_schedule_ids"
+                    optional="hide"
+                    widget="many2many_tags"
+                />
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='analytic_account_id']" position="after">
                 <field name="logistics_schedule_id" />
+                <field
+                    name="agg_logistics_schedule_ids"
+                    widget="many2many_tags"
+                />
             </xpath>
         </field>
     </record>

--- a/logistics_planning_invoicing/views/logistics_schedule_views.xml
+++ b/logistics_planning_invoicing/views/logistics_schedule_views.xml
@@ -18,7 +18,12 @@
         <field name="inherit_id" ref="logistics_planning_base.logistics_schedule_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <button name="action_create_invoice_wizard" type="object" string="Create Invoice" attrs="{'invisible': ['|', ('is_invoiceable', '=', False), '|', ('account_move_line_id', '!=', False), ('state', '=', 'done')]}"/>
+                <button
+                    name="action_create_invoice_wizard"
+                    type="object" string="Create Invoice"
+                    attrs="{'invisible': ['|', ('is_invoiceable', '=', False), '|', ('account_move_line_id', '!=', False), ('state', '=', 'done')]}"
+                    icon="fa-pencil-square-o"
+                />
             </xpath>
             <xpath expr="//field[@name='transport_type']" position="before">
                 <field

--- a/logistics_planning_invoicing/wizards/logistics_schedule_account_move_wizard.py
+++ b/logistics_planning_invoicing/wizards/logistics_schedule_account_move_wizard.py
@@ -13,6 +13,13 @@ class LogisticsScheduleAccountMove(models.TransientModel):
     carrier_id = fields.Many2one('res.partner', readonly=True)
     journal_id = fields.Many2one('account.journal', default=lambda self: self.env.user.company_id.logistics_schedule_default_journal_id.id)
     ref = fields.Char(string="Bill Reference")
+    group_lines = fields.Boolean(
+        default=True,
+        help=
+        """
+        When checked, created invoice lines will be made in aggregated mode
+        """,
+    )
 
     def create_invoice(self):
         action = self.env.ref('account.action_move_in_invoice_type')
@@ -23,12 +30,12 @@ class LogisticsScheduleAccountMove(models.TransientModel):
             "default_journal_id": self.journal_id.id,
             "default_company_id": self.company_id.id,
             "default_ref": self.ref,
+            "group_lines": self.group_lines,
         })
         res = self.env.ref('account.view_move_form', False)
         form_view = [(res and res.id or False, 'form')]
         result['views'] = form_view
 
-        # TODO why this line?
         result['context']['logistics_schedule_ids'] = self.logistics_schedule_ids.ids
 
         return result

--- a/logistics_planning_invoicing/wizards/logistics_schedule_account_move_wizard_views.xml
+++ b/logistics_planning_invoicing/wizards/logistics_schedule_account_move_wizard_views.xml
@@ -14,6 +14,7 @@
                         </group>
                         <group>
                             <field name="journal_id" />
+                            <field name="group_lines" />
                         </group>
                         <group colspan="2">
                             <field name="logistics_schedule_ids" nolabel="1">


### PR DESCRIPTION
This improvement enables by default grouping selected logistics schedules to be invoiced in the same line if some of them shares the same values, making aggregation according price unit type expected behavior.

Grouping criteria by:
- product (replacing account, that is not available at this point)
- analytic account
- product unit of measure
- price unit type
- (OPT) price unit

When aggregating,
- If product unit of measure is 'trip' => adding to price unit
- If product unit of measure is 'unit' => adding to price qty

-------

This PR also adds a minor improvement for LP forms (added icon for "Create Invoice" action)