### PR TITLE
[13.0][IMP] logistics_planning_purchase: new option - create schedules only for one PO line

### DIFF
--- a/logistics_planning_purchase/__manifest__.py
+++ b/logistics_planning_purchase/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.3.0',
+    'version': '13.0.1.4.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_purchase/i18n/es.po
+++ b/logistics_planning_purchase/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-22 11:15+0000\n"
-"PO-Revision-Date: 2024-07-22 11:15+0000\n"
+"POT-Creation-Date: 2024-08-27 09:15+0000\n"
+"PO-Revision-Date: 2024-08-27 09:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -196,6 +196,16 @@ msgid "New schedules to be added"
 msgstr "Nuevas planificaciones a añadir"
 
 #. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.purchase_order_view_form_inherit_all
+msgid "Only sched. for 1 line"
+msgstr "Solo planif. para 1 línea"
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_purchase_order__logistics_schedule_one_line
+msgid "Only schedule one line"
+msgstr "Solo planificación para una línea"
+
+#. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule__purchase_order_id
 msgid "Order Reference"
 msgstr "Ref. pedido"
@@ -209,11 +219,8 @@ msgstr "Tipo de Albarán"
 #: code:addons/logistics_planning_purchase/models/purchase_order.py:0
 #, python-format
 msgid ""
-"Please fill a valid Initial required schedules (>=0) for every order line "
-"for the following orders: %s"
-msgstr ""
-"Por favor cubra un Nº inicial de planif. requeridas válido (>0) para cada "
-"línea para los siguientes pedidos: %s"
+"Please fill a valid Initial required schedules (>=0) for line(s) of %s order"
+msgstr "Por favor cubra un Nº inicial de planif. requeridas válido (>0) para las lineas del pedido %s"
 
 #. module: logistics_planning_purchase
 #: code:addons/logistics_planning_purchase/wizards/logistics_schedule_purchase_add_wizard.py:0

--- a/logistics_planning_purchase/i18n/logistics_planning_purchase.pot
+++ b/logistics_planning_purchase/i18n/logistics_planning_purchase.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-22 11:14+0000\n"
-"PO-Revision-Date: 2024-07-22 11:14+0000\n"
+"POT-Creation-Date: 2024-08-27 09:11+0000\n"
+"PO-Revision-Date: 2024-08-27 09:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -183,6 +183,16 @@ msgid "New schedules to be added"
 msgstr ""
 
 #. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.purchase_order_view_form_inherit_all
+msgid "Only sched. for 1 line"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_purchase_order__logistics_schedule_one_line
+msgid "Only schedule one line"
+msgstr ""
+
+#. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule__purchase_order_id
 msgid "Order Reference"
 msgstr ""
@@ -196,8 +206,7 @@ msgstr ""
 #: code:addons/logistics_planning_purchase/models/purchase_order.py:0
 #, python-format
 msgid ""
-"Please fill a valid Initial required schedules (>=0) for every order line "
-"for the following orders: %s"
+"Please fill a valid Initial required schedules (>=0) for line(s) of %s order"
 msgstr ""
 
 #. module: logistics_planning_purchase

--- a/logistics_planning_purchase/models/purchase_order.py
+++ b/logistics_planning_purchase/models/purchase_order.py
@@ -33,6 +33,12 @@ class PurchaseOrder(models.Model):
         },
         tracking=True,
     )
+    logistics_schedule_one_line = fields.Boolean(
+        string="Only schedule one line",
+        default=False,
+        copy=False,
+        tracking=True,
+    )
     logistics_account_move_ids = fields.Many2many(
         comodel_name="account.move",
         compute="_compute_logistics_account_moves",
@@ -52,6 +58,14 @@ class PurchaseOrder(models.Model):
             self.logistics_schedule_disabled = (
                 self.picking_type_id.ls_po_create_disable_default
             )
+
+    @api.onchange("logistics_schedule_disabled")
+    def _onchange_logistics_schedule_disabled(self):
+        if (
+            self.logistics_schedule_disabled
+            and self.logistics_schedule_one_line
+        ):
+            self.logistics_schedule_one_line = False
 
     def _compute_logistics_account_moves(self):
         for po in self:
@@ -90,24 +104,28 @@ class PurchaseOrder(models.Model):
         return result        
 
     def button_approve(self):
-        bad_order_lines = self.order_line.filtered(
-            lambda x: x.ls_schedule_allowed and x.logistics_schedule_init <= 0
-        )
-        if bad_order_lines:
-            bad_orders = bad_order_lines.order_id.mapped("name")
-            raise ValidationError(
-                _(
-                    "Please fill a valid Initial required schedules (>=0)"
-                    " for every order line for the following orders: %s"
-                ) % ", ".join(bad_orders)
-            )
-        res = super().button_approve()
+        res = {}
         ls_values = []
-        for line in self.order_line.filtered(lambda x: x.ls_schedule_allowed):
-            ls_values += [
-                line._prepare_logistics_schedule()
-                for i in range(0, line.logistics_schedule_init)
-            ]
+        for order in self:
+            ls_line_ids = order.order_line.filtered(lambda x: x.ls_schedule_allowed)
+            if ls_line_ids and order.logistics_schedule_one_line:
+                ls_line_ids = ls_line_ids[0]
+            bad_order_lines = order.order_line.filtered(
+                lambda x: x.ls_schedule_allowed and x.logistics_schedule_init <= 0
+            )
+            if bad_order_lines and (ls_line_ids & bad_order_lines):
+                raise ValidationError(
+                    _(
+                        "Please fill a valid Initial required schedules (>=0)"
+                        " for line(s) of %s order"
+                    ) % order.name
+                )
+            res = super(PurchaseOrder, order).button_approve()
+            for line in ls_line_ids:
+                ls_values += [
+                    line._prepare_logistics_schedule()
+                    for i in range(0, line.logistics_schedule_init)
+                ]
         if ls_values:
             ls_ids = self.env["logistics.schedule"].sudo().create(ls_values)
             ls_ids._action_ready()

--- a/logistics_planning_purchase/views/purchase_order_views.xml
+++ b/logistics_planning_purchase/views/purchase_order_views.xml
@@ -31,6 +31,19 @@
                     string="Disable log. sched."
                     attrs="{'invisible': [('logistics_schedule_skip','=',True)]}"
                 />
+                <field
+                    name="logistics_schedule_one_line"
+                    widget="boolean_toggle"
+                    string="Only sched. for 1 line"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                            ('logistics_schedule_disabled','=',True),
+                            ('logistics_schedule_skip','=',True),
+                        ],
+                        'readonly': [('state', 'in', ['purchase','done','cancel'])],
+                    }"
+                />
             </xpath>            
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='sequence']"


### PR DESCRIPTION
With this improvement, when a PO is confirmed and is selected the proper option, only schedules for the first PO line will be created.

TODO
* Translations
* Install in AluTest environment and testing by customer