### PR TITLE
[13.0][FIX] logistics_planning_invoicing: duplicate, delete and schedule count issues

### DIFF
--- a/logistics_planning_invoicing/__manifest__.py
+++ b/logistics_planning_invoicing/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.2.0.0',
+    'version': '13.0.2.0.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     'depends': [

--- a/logistics_planning_invoicing/models/account_move.py
+++ b/logistics_planning_invoicing/models/account_move.py
@@ -7,6 +7,8 @@ from odoo import models, fields, api
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
+    # TODO rename this field, as strictly reflects "initially linked logistic
+    #      schedules", only used during invoice creation
     logistics_schedule_ids = fields.Many2many(
         'logistics.schedule',
         'account_move_id',
@@ -35,7 +37,10 @@ class AccountMove(models.Model):
 
     def _compute_logistics_schedule_count(self):
         for record in self:
-            record.logistics_schedule_count = len(record.logistics_schedule_ids)
+            record.logistics_schedule_count = sum(
+                len(aml._get_all_logistics_schedule_ids())
+                for aml in record.invoice_line_ids
+            )
 
     def button_cancel(self):
         # TODO prevent user with warning?
@@ -48,13 +53,4 @@ class AccountMove(models.Model):
         return super().unlink()
 
     def _ls_secure_unlink(self):
-        ls_ids = self.invoice_line_ids.sudo()._get_all_logistics_schedule_ids()
-        if ls_ids:
-            ls_ids.account_move_line_id.write({
-                "logistics_schedule_id": False,
-                "agg_logistics_schedule_ids": False,
-            })
-            ls_ids.write({
-                "account_move_line_id": False,
-                "state": "ready",
-            })
+        self.invoice_line_ids._ls_secure_unlink()

--- a/logistics_planning_invoicing/models/account_move_line.py
+++ b/logistics_planning_invoicing/models/account_move_line.py
@@ -7,9 +7,10 @@ from odoo import models, fields, api
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    logistics_schedule_id = fields.Many2one('logistics.schedule')
+    logistics_schedule_id = fields.Many2one('logistics.schedule', copy=False)
     agg_logistics_schedule_ids = fields.Many2many(
         comodel_name="logistics.schedule",
+        copy=False,
         string="Aggregated logistics schedules",
     )
 
@@ -43,3 +44,20 @@ class AccountMoveLine(models.Model):
             else:
                 self.logistics_schedule_id.account_move_line_id = False
         return super().write(values)
+
+    def unlink(self):
+        # TODO prevent user with warning?
+        self._ls_secure_unlink()
+        return super().unlink()
+
+    def _ls_secure_unlink(self):
+        ls_ids = self.sudo()._get_all_logistics_schedule_ids()
+        if ls_ids:
+            ls_ids.account_move_line_id.write({
+                "logistics_schedule_id": False,
+                "agg_logistics_schedule_ids": False,
+            })
+            ls_ids.write({
+                "account_move_line_id": False,
+                "state": "ready",
+            })


### PR DESCRIPTION
This commit fixes the following bugs:
* When an invoice was duplicated, related schedules were also linked to the new invoice. A schedule cannot be linked to more than an invoice line.
* When a draft invoice with linked schedules was deleted, every schedule was unlinked as well (ok), but the same didn't occur when a single invoice line was removed. Now, such check is made at invoice line level.
* Invoice schedule count became wrong when lines with linked schedules were remove.

cc @ChristianSantamaria 