### PR TITLE
[13.0][IMP] logistics_planning_purchase: adds default product for one line

### DIFF
--- a/logistics_planning_purchase/__manifest__.py
+++ b/logistics_planning_purchase/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.5.0',
+    'version': '13.0.1.6.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [
@@ -18,6 +18,7 @@
         "views/logistics_schedule_views.xml",
         "views/purchase_order_views.xml",
         "views/stock_picking_type_views.xml",
+        "views/res_config_settings_views.xml",
         "wizards/logistics_schedule_purchase_add_wizard_views.xml",
     ],
 }

--- a/logistics_planning_purchase/i18n/es.po
+++ b/logistics_planning_purchase/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 08:08+0000\n"
-"PO-Revision-Date: 2024-11-15 08:08+0000\n"
+"POT-Creation-Date: 2024-11-22 08:43+0000\n"
+"PO-Revision-Date: 2024-11-22 08:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -70,6 +70,16 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: logistics_planning_purchase
+#: model:ir.model,name:logistics_planning_purchase.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: logistics_planning_purchase
+#: model:ir.model,name:logistics_planning_purchase.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de Configuración"
+
+#. module: logistics_planning_purchase
 #: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.view_logistics_schedule_purchase_add_wizard
 msgid "Create Schedules"
 msgstr "Crear planificaciones"
@@ -93,6 +103,12 @@ msgstr "Moneda"
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__ls_count
 msgid "Current schedule count"
 msgstr "Número actual de planificaciones"
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_res_company__ls_default_one_line_product_id
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_res_config_settings__ls_default_one_line_product_id
+msgid "Default product in purchase for one line"
+msgstr "Producto por defecto en compras para planificacion de una línea"
 
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_stock_picking_type__ls_po_create_disable_default
@@ -240,6 +256,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__product_id
 msgid "Product"
 msgstr "Producto"
+
+#. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.res_config_settings_view_form
+msgid "Purchase"
+msgstr "Compras"
 
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__purchase_line_id

--- a/logistics_planning_purchase/i18n/logistics_planning_purchase.pot
+++ b/logistics_planning_purchase/i18n/logistics_planning_purchase.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 08:07+0000\n"
-"PO-Revision-Date: 2024-11-15 08:07+0000\n"
+"POT-Creation-Date: 2024-11-22 08:43+0000\n"
+"PO-Revision-Date: 2024-11-22 08:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -57,6 +57,16 @@ msgid "Cancel"
 msgstr ""
 
 #. module: logistics_planning_purchase
+#: model:ir.model,name:logistics_planning_purchase.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model:ir.model,name:logistics_planning_purchase.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: logistics_planning_purchase
 #: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.view_logistics_schedule_purchase_add_wizard
 msgid "Create Schedules"
 msgstr ""
@@ -79,6 +89,12 @@ msgstr ""
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__ls_count
 msgid "Current schedule count"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_res_company__ls_default_one_line_product_id
+#: model:ir.model.fields,field_description:logistics_planning_purchase.field_res_config_settings__ls_default_one_line_product_id
+msgid "Default product in purchase for one line"
 msgstr ""
 
 #. module: logistics_planning_purchase
@@ -224,6 +240,11 @@ msgstr ""
 #. module: logistics_planning_purchase
 #: model:ir.model.fields,field_description:logistics_planning_purchase.field_logistics_schedule_purchase_add_wizard__product_id
 msgid "Product"
+msgstr ""
+
+#. module: logistics_planning_purchase
+#: model_terms:ir.ui.view,arch_db:logistics_planning_purchase.res_config_settings_view_form
+msgid "Purchase"
 msgstr ""
 
 #. module: logistics_planning_purchase

--- a/logistics_planning_purchase/models/__init__.py
+++ b/logistics_planning_purchase/models/__init__.py
@@ -3,3 +3,4 @@ from . import purchase_order_line
 from . import purchase_order
 from . import stock_picking
 from . import stock_picking_type
+from . import res_config_settings

--- a/logistics_planning_purchase/models/purchase_order_line.py
+++ b/logistics_planning_purchase/models/purchase_order_line.py
@@ -49,13 +49,15 @@ class PurchaseOrderLine(models.Model):
 
     def _prepare_logistics_schedule(self):
         self.ensure_one()
+        product_id = self.company_id.ls_default_one_line_product_id if self.order_id.logistics_schedule_one_line and self.company_id.ls_default_one_line_product_id else self.product_id
+
         return {
             "type": "input",
             "origin": self.order_id.name,
             "company_id": self.company_id.id,
             "destination_partner_id": self.order_id.picking_type_id.warehouse_id.partner_id.id,
             "partner_id": self.partner_id.id,
-            "product_id": self.product_id.id,
+            "product_id": product_id.id,
             "product_uom": self.product_uom.id,
             # TODO confirm this field
             "scheduled_load_date": self.date_planned,

--- a/logistics_planning_purchase/models/res_config_settings.py
+++ b/logistics_planning_purchase/models/res_config_settings.py
@@ -1,0 +1,23 @@
+# © 2024 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    ls_default_one_line_product_id = fields.Many2one(
+        related="company_id.ls_default_one_line_product_id",
+        readonly=False,
+    )
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    ls_default_one_line_product_id = fields.Many2one(
+        comodel_name="product.product",
+        domain="[('type', '=', 'product')]",
+        string="Default product in purchase for one line",
+    )

--- a/logistics_planning_purchase/views/res_config_settings_views.xml
+++ b/logistics_planning_purchase/views/res_config_settings_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="logistics_planning_base.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='logistics_planning_base']" position="inside">
+                <h2>Purchase</h2>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane"/>
+                        <div class="o_setting_right_pane">
+                            <label for="ls_default_one_line_product_id"/>
+                            <div class="text-muted"/>
+                            <div class="content-group">
+                                <div class="mt16">
+                                    <field name="ls_default_one_line_product_id"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
@dalonsod 
In the case of prepare schedule for a line, instead of selecting the product of the line, the default product for purchases of a line is selected in res.config.settings