### PR TITLE
[13.0][FIX] stock_move_lot_qty_total: missing rounding in served quantity comparison

### DIFF
--- a/stock_move_lot_qty_total/__manifest__.py
+++ b/stock_move_lot_qty_total/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "category": "Inventory/Inventory",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": ["stock"],

--- a/stock_move_lot_qty_total/models/stock_move_line.py
+++ b/stock_move_lot_qty_total/models/stock_move_line.py
@@ -2,6 +2,7 @@
 # License LGPL-3 - See http://www.gnu.org/licenses/lgpl-3.0.html
 from odoo import _, models
 from odoo.exceptions import ValidationError
+from odoo.tools.float_utils import float_compare
 
 
 class StockMoveLine(models.Model):
@@ -23,9 +24,12 @@ class StockMoveLine(models.Model):
             and x.product_id.lot_stock_total_quantities
         )
         for sml in sml_to_check_ids:
-            # TODO float compare?
             available_qty = sml._get_available_quantity_complete_lot()
-            if sml.qty_done != available_qty:
+            if float_compare(
+                sml.qty_done,
+                available_qty,
+                precision_rounding=sml.product_id.uom_id.rounding or 0.001
+            ) != 0:
                 raise ValidationError(_(
                     "Done quantity for %s with lot %s doesn't match available"
                     " stock (%.3f != %.3f), please check"


### PR DESCRIPTION
Strict comparison between two float fields should be implemented using `float_compare` if possible. Quantities in a stock move line and a stock quant could differ in a n-th decimal and break comparison. This fixes it.