### PR TITLE
[13.0][IMP] logistics_planning_sale: enable sale line initial schedule count to be copied

### DIFF
--- a/logistics_planning_sale/__manifest__.py
+++ b/logistics_planning_sale/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.7.0',
+    'version': '13.0.1.8.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_sale/models/sale_order_line.py
+++ b/logistics_planning_sale/models/sale_order_line.py
@@ -25,7 +25,6 @@ class SaleOrderLine(models.Model):
     logistics_price_unit = fields.Float(digits="Product Price")
     logistics_schedule_init = fields.Integer(
         string="Initial required schedules",
-        copy=False,
     )
     ls_transport_type = fields.Selection(
         selection=TRANSPORT_TYPE,


### PR DESCRIPTION
With this improvement, when a sale line is copied, initial schedule count is copied as well, that is useful for users.