### PR TITLE
[13.0][FIX] stock_picking_mgmt_weight: purchase lines - prevent copy incorrect fields

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.26.1",
+    "version": "13.0.1.26.2",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/models/purchase_order_line.py
+++ b/stock_picking_mgmt_weight/models/purchase_order_line.py
@@ -27,7 +27,7 @@ class PurchaseOrderLine(models.Model):
         compute="_compute_classification_order_line_ids",
         store=True,
     )
-    classified = fields.Boolean(default=False)
+    classified = fields.Boolean(default=False, copy=False)
     pending_qty = fields.Float(
         compute='_compute_pending_qty',
         digits='Product Unit of Measure',
@@ -85,7 +85,8 @@ class PurchaseOrderLine(models.Model):
     )
     qty_classified = fields.Float(
         digits='Product Unit of Measure',
-        readonly=True
+        readonly=True,
+        copy=False,
     )
 
     date_planned_search = fields.Date(
@@ -97,6 +98,7 @@ class PurchaseOrderLine(models.Model):
     identification_document_number = fields.Char(
         help="This code should be unique for an order and product LER code"
         " and should come from GAIA integration",
+        copy=False,
     )
 
     order_user_id = fields.Many2one(related="order_id.user_id")


### PR DESCRIPTION
These three fields were copied during a PO duplication, their content is unique for every purchase line and shouldn't be copied.

cc @ChristianSantamaria 

HT00337