### PR TITLE
[13.0][IMP] logistics_planning_purchase: enable purchase line initial schedule count to be copied

### DIFF
--- a/logistics_planning_purchase/__manifest__.py
+++ b/logistics_planning_purchase/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.6.0',
+    'version': '13.0.1.7.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_purchase/models/purchase_order_line.py
+++ b/logistics_planning_purchase/models/purchase_order_line.py
@@ -27,7 +27,6 @@ class PurchaseOrderLine(models.Model):
     )
     logistics_schedule_init = fields.Integer(
         string="Initial required schedules",
-        copy=False,
     )
     ls_schedule_allowed = fields.Boolean(
         compute="_compute_ls_schedule_allowed",


### PR DESCRIPTION
With this improvement, when a purchase line is copied, initial schedule count is copied as well, that is useful for users.

cc @ChristianSantamaria 

Required for HT00537