### PR TITLE
[13.0][FIX] stock_move_lot_qty_total: prevent duplicated lot selection

### DIFF
--- a/stock_move_lot_qty_total/__manifest__.py
+++ b/stock_move_lot_qty_total/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.1.0.1",
+    "version": "15.0.1.0.2",
     "category": "Inventory/Inventory",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": ["stock"],

--- a/stock_move_lot_qty_total/i18n/es.po
+++ b/stock_move_lot_qty_total/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-03 15:42+0000\n"
-"PO-Revision-Date: 2025-01-03 16:47+0100\n"
+"POT-Creation-Date: 2025-02-07 12:02+0000\n"
+"PO-Revision-Date: 2025-02-07 13:04+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -75,6 +75,18 @@ msgid ""
 msgstr ""
 "Hay al menos un movimiento de producto sin lote seleccionado, por favor "
 "revise"
+
+#. module: stock_move_lot_qty_total
+#: code:addons/stock_move_lot_qty_total/models/stock_move.py:0
+#, python-format
+msgid ""
+"There are lot(s) duplicated, please remove duplicated.\n"
+"\n"
+"Repeated lots: %s"
+msgstr ""
+"Hay seleccionados lot(es) duplicado(s), por favor elimínelos.\n"
+"\n"
+"Lotes repetidos: %s"
 
 #. module: stock_move_lot_qty_total
 #: code:addons/stock_move_lot_qty_total/models/stock_move.py:0

--- a/stock_move_lot_qty_total/i18n/stock_move_lot_qty_total.pot
+++ b/stock_move_lot_qty_total/i18n/stock_move_lot_qty_total.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-03 15:42+0000\n"
-"PO-Revision-Date: 2025-01-03 15:42+0000\n"
+"POT-Creation-Date: 2025-02-07 12:02+0000\n"
+"PO-Revision-Date: 2025-02-07 12:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -66,6 +66,15 @@ msgstr ""
 #, python-format
 msgid ""
 "There are at least one stock move line without lot selected, please check"
+msgstr ""
+
+#. module: stock_move_lot_qty_total
+#: code:addons/stock_move_lot_qty_total/models/stock_move.py:0
+#, python-format
+msgid ""
+"There are lot(s) duplicated, please remove duplicated.\n"
+"\n"
+"Repeated lots: %s"
 msgstr ""
 
 #. module: stock_move_lot_qty_total

--- a/stock_move_lot_qty_total/models/stock_move.py
+++ b/stock_move_lot_qty_total/models/stock_move.py
@@ -44,6 +44,19 @@ class StockMove(models.Model):
                 "There are at least one stock move line without lot selected,"
                 " please check"
             ))
+        # Check that every move line lot is unique and find which are duplicated
+        lot_list = self.move_line_ids.mapped("lot_id")
+        if len(lot_list) < len(self.move_line_ids):
+            repeated_lots = []
+            for lot in lot_list:
+                if len(self.move_line_ids.filtered(lambda x: x.lot_id == lot)) > 1:
+                    repeated_lots.append(lot.name)
+            raise ValidationError(
+                _(
+                    "There are lot(s) duplicated, please remove duplicated.\n\n"
+                    "Repeated lots: %s"
+                ) % ", ".join(repeated_lots)
+            )
         # TODO ensure right unit of measure
         for ml in self.move_line_ids:
             available_qty = ml._get_available_quantity_complete_lot()


### PR DESCRIPTION
Before this fix, it was possible to select twice or more a lot during lot selection.

With this fix, when smart lot quantity selection is used, lot duplication raises an error.