### PR TITLE
[16.0][FIX] stock_picking_deliver_to: move deliver_to field to a second line in the report

### DIFF
--- a/stock_picking_deliver_to/__manifest__.py
+++ b/stock_picking_deliver_to/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "16.0.0.0.0",
+    "version": "16.0.1.0.1",
     "category": "Stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": ["stock"],

--- a/stock_picking_deliver_to/reports/stock_picking.xml
+++ b/stock_picking_deliver_to/reports/stock_picking.xml
@@ -2,12 +2,14 @@
 <odoo>
     <data>
         <template id="report_stock_picking" inherit_id="stock.report_delivery_document">
-            <xpath expr="//div[@name='div_sched_date']" position="after">
-                <div class="col-auto" t-if="o.deliver_to != False">
-                    <strong>Deliver to:</strong>
-                    <p t-field="o.deliver_to" />
+            <xpath expr="//div[@name='div_sched_date']/.." position="after">
+                <div>
+                    <div class="col-auto" t-if="o.deliver_to != False">
+                        <strong>Deliver to:</strong>
+                        <p style="display:inline; margin-left:1px;" t-field="o.deliver_to"/>
+                    </div>
                 </div>
             </xpath>
-        </template>       
+        </template>
     </data>
 </odoo>


### PR DESCRIPTION
This fix is apllied due to a general update in Odoo which the deliver_to field was not displaying correctly.

@dalonsod 