### PR TITLE
[13.0][FIX] stock_valuation: proper independent outgoing pickings management

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.4.0",
+    "version": "13.0.3.4.1",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_valuation/models/stock_valuation_layer.py
+++ b/stock_valuation/models/stock_valuation_layer.py
@@ -144,10 +144,10 @@ class StockValuationLayer(models.Model):
                         )
 
                 elif move_id.picking_type_id.code == 'outgoing':
-                    # Sale order (original or "2*N return")
+                    # Sale order (original or "2*N return") OR independent outgoing (direct from warehouse)
                     # TODO remove it? It should be later recalculated
                     # if not move_id.origin_returned_move_id:
-                    if move_id.sale_line_id:
+                    if move_id.sale_line_id or (not move_id.sale_line_id and not move_id.purchase_line_id):
                         vals["unit_cost"] = move_id.product_id.standard_price_warehouse_ids.filtered(lambda x: x.warehouse_id.id == move_id.picking_type_id.warehouse_id.id).average_price
                         vals["value"] = vals.get("unit_cost") * vals.get("quantity")
                     # Purchase return "2*N + 1"


### PR DESCRIPTION
Before this fix, standalone outgoing pickings, that are not linked to sales, or purchase returns, were not properly managed. SVL records were treated as "accumulated", with zero price, then average price was wrongly incremented.
This issue, also raised an error for some limit cases, due to a division by zero (when the outgoing move set to 0 warehouse stock and create a new PHAP day record as well).

This fix makes these outputs work like e.g. a Sales output, that is a simple case (valuated as average price of the output day)