### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight: restriction valid weight max age

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.28.0",
+    "version": "13.0.1.29.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [
@@ -53,6 +53,7 @@
         # "report/report_stock_expected_quantity.xml",
         "views/sale_order_views.xml",
         "views/sale_order_line_views.xml",
+        "views/scale_scale_views.xml",
         "views/shipping_resource_views.xml",
         "views/supply_condition_views.xml",
         "views/vehicle_type_views.xml",

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-17 10:28+0000\n"
-"PO-Revision-Date: 2025-07-17 10:28+0000\n"
+"POT-Creation-Date: 2025-11-05 08:12+0000\n"
+"PO-Revision-Date: 2025-11-05 08:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -318,6 +318,12 @@ msgid "Cannot retrieve weight, an error was obtained. Please try again later"
 msgstr ""
 "No se puede capturar el peso, se ha obtenido error. Pruebe de nuevo más "
 "tarde"
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid "Cannot retrieve weight, it's tool old (%d, more than %d s ago)"
+msgstr "No se puede obtener el peso, es demasiado antiguo (%d, máximo %d segundos)."
 
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.stock_move_mgmt_weight_frontend_weight_form_view
@@ -1408,6 +1414,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model,name:stock_picking_mgmt_weight.model_scale_scale
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.res_config_settings_scale_view_form
 msgid "Scale"
 msgstr "Báscula"
@@ -1796,6 +1803,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit
 msgid "VGM"
 msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_scale_scale__valid_weight_max_age_secs
+msgid "Valid Weight Max Age Secs"
+msgstr "Tiempo máx. válido del peso (s)"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move__weight_image_mini

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-17 10:28+0000\n"
-"PO-Revision-Date: 2025-07-17 10:28+0000\n"
+"POT-Creation-Date: 2025-11-05 08:12+0000\n"
+"PO-Revision-Date: 2025-11-05 08:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -283,6 +283,12 @@ msgstr ""
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Cannot retrieve weight, an error was obtained. Please try again later"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid "Cannot retrieve weight, it's tool old (%d, more than %d s ago)"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1360,6 +1366,7 @@ msgid "Save"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
+#: model:ir.model,name:stock_picking_mgmt_weight.model_scale_scale
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.res_config_settings_scale_view_form
 msgid "Scale"
 msgstr ""
@@ -1738,6 +1745,11 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_stock_picking_weight_form_inherit
 msgid "VGM"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_scale_scale__valid_weight_max_age_secs
+msgid "Valid Weight Max Age Secs"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/models/__init__.py
+++ b/stock_picking_mgmt_weight/models/__init__.py
@@ -15,3 +15,4 @@ from . import sale_order
 from . import sale_order_line
 from . import supply_condition
 from . import vehicle_type
+from . import scale_scale

--- a/stock_picking_mgmt_weight/models/scale_scale.py
+++ b/stock_picking_mgmt_weight/models/scale_scale.py
@@ -1,0 +1,10 @@
+# © 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import models, fields
+
+class Scale(models.Model):
+    _inherit = 'scale.scale'
+
+    valid_weight_max_age_secs = fields.Integer(default=10)
+

--- a/stock_picking_mgmt_weight/models/stock_move.py
+++ b/stock_picking_mgmt_weight/models/stock_move.py
@@ -339,6 +339,11 @@ class StockMovFrontend(models.Model):
                 raise ValidationError(
                     _("Cannot retrieve weight, an error was obtained. Please try again later")
                 )
+            diff_seconds = (fields.Datetime.now() - scale.last_weight_dt).total_seconds()
+            if diff_seconds > scale.valid_weight_max_age_secs:
+                raise ValidationError(
+                    _("Cannot retrieve weight, it's tool old (%d, more than %d s ago)") % (int(diff_seconds), scale.valid_weight_max_age_secs)
+                )
             weight = scale.last_weight
             return scale.uom_id._compute_quantity(weight, self.product_uom)
         else:

--- a/stock_picking_mgmt_weight/views/scale_scale_views.xml
+++ b/stock_picking_mgmt_weight/views/scale_scale_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_scale_scale_form" model="ir.ui.view">
+        <field name="name">scale.scale.form (in stock_picking_mgmt_weight)</field>
+        <field name="model">scale.scale</field>
+        <field name="inherit_id" ref="scale.view_scale_scale_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='time_between_attempt']" position="after">
+                <field name="valid_weight_max_age_secs" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds a new validation to ensure that recorded weights are not older than the configured maximum age (in seconds). Prevents using outdated weight readings when processing pickings or operations.