### PR TITLE
[13.0][IMP] stock_picking_mgmt_weight, logistics_planning_mgmt_weight: ticket deletion protections and permissions

### DIFF
--- a/logistics_planning_mgmt_weight/__manifest__.py
+++ b/logistics_planning_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.9.0',
+    'version': '13.0.1.10.0',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_mgmt_weight/i18n/es.po
+++ b/logistics_planning_mgmt_weight/i18n/es.po
@@ -6,16 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-22 11:16+0000\n"
-"PO-Revision-Date: 2024-07-22 13:21+0200\n"
+"POT-Creation-Date: 2025-12-03 09:14+0000\n"
+"PO-Revision-Date: 2025-12-03 09:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 3.0.1\n"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields,help:logistics_planning_mgmt_weight.field_stock_move__aux_picking_partner_id
@@ -28,8 +26,7 @@ msgid ""
 "        "
 msgstr ""
 "\n"
-"        Campo técnico usado como workaround cuando se necesita rellenar "
-"previamente\n"
+"        Campo técnico usado como workaround cuando se necesita rellenar previamente\n"
 "        desde una acción picking_parter_id con el default_.\n"
 "        Esto ocurre cuando queremos crear un nuevo ticket desde una\n"
 "        planificación logística como borrador\n"
@@ -46,8 +43,7 @@ msgid ""
 "        "
 msgstr ""
 "\n"
-"        Campo técnico usado como workaround cuando se necesita rellenar "
-"previamente\n"
+"        Campo técnico usado como workaround cuando se necesita rellenar previamente\n"
 "        desde una acción picking_vehicle_id con el default_.\n"
 "        Esto ocurre cuando queremos crear un nuevo ticket desde una\n"
 "        planificación logística como borrador\n"
@@ -88,12 +84,12 @@ msgstr "Marítimo"
 #, python-format
 msgid ""
 "One or more of the selected schedules cannot be marked as finished because "
-"one of their tickets are still uncomplete (without net weight). Please "
-"check them"
+"one of their tickets are still uncomplete (without net weight). Please check"
+" them"
 msgstr ""
 "No se puede marcar como finalizada una o más de las planificaciones "
-"seleccionadas porque uno de sus tickets relacionados está todavía "
-"incompleto (sin peso neto). Por favor, revíselos"
+"seleccionadas porque uno de sus tickets relacionados está todavía incompleto"
+" (sin peso neto). Por favor, revíselos"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model.fields,field_description:logistics_planning_mgmt_weight.field_logistics_schedule__extra_stock_move_ids
@@ -176,6 +172,16 @@ msgstr "Tip. veh."
 #, python-format
 msgid "Vehicle Type"
 msgstr "Tipo de vehículo"
+
+#. module: logistics_planning_mgmt_weight
+#: code:addons/logistics_planning_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot delete the following weigh-in tickets because they have an "
+"assigned logistic schedule: %s"
+msgstr ""
+"No puede eliminar los siguientes tickets de pesada porque tienen una "
+"planificación logística asignada: %s"
 
 #. module: logistics_planning_mgmt_weight
 #: model:ir.model,name:logistics_planning_mgmt_weight.model_logistics_schedule

--- a/logistics_planning_mgmt_weight/i18n/logistics_planning_mgmt_weight.pot
+++ b/logistics_planning_mgmt_weight/i18n/logistics_planning_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-22 11:15+0000\n"
-"PO-Revision-Date: 2024-07-22 11:15+0000\n"
+"POT-Creation-Date: 2025-12-03 09:19+0000\n"
+"PO-Revision-Date: 2025-12-03 09:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -154,6 +154,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:logistics_planning_mgmt_weight.field_logistics_schedule__vehicle_type_id
 #, python-format
 msgid "Vehicle Type"
+msgstr ""
+
+#. module: logistics_planning_mgmt_weight
+#: code:addons/logistics_planning_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot delete the following weigh-in tickets because they have an "
+"assigned logistic schedule: %s"
 msgstr ""
 
 #. module: logistics_planning_mgmt_weight

--- a/logistics_planning_mgmt_weight/models/stock_move.py
+++ b/logistics_planning_mgmt_weight/models/stock_move.py
@@ -1,7 +1,8 @@
 # © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class StockMove(models.Model):
@@ -63,3 +64,13 @@ class StockMove(models.Model):
                 #ls.extra_stock_move_ids = [(4, res.id)]
                 ls.extra_stock_move_ids += res
         return res
+
+    def unlink(self):
+        logisted_move_ids = self.filtered(lambda x: x.logistics_schedule_id)
+        if logisted_move_ids:
+            move_ids = ', '.join(map(lambda x: x.picking_id.name, logisted_move_ids))
+            raise ValidationError(
+                _("You cannot delete the following weigh-in tickets because they have an assigned logistic schedule: %s") % move_ids
+            )
+
+        return super(StockMove, self).unlink()

--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.29.0",
+    "version": "13.0.1.30.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/i18n/es.po
+++ b/stock_picking_mgmt_weight/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-05 08:12+0000\n"
-"PO-Revision-Date: 2025-11-05 08:12+0000\n"
+"POT-Creation-Date: 2025-12-03 09:02+0000\n"
+"PO-Revision-Date: 2025-12-03 09:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -75,14 +75,12 @@ msgstr ""
 " * Cancelado: la transferencia ha sido cancelada."
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #, python-format
 msgid "%s-%s (%.2f pend.)"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "/weight_images/%s"
@@ -162,7 +160,6 @@ msgid "Announced"
 msgstr "Anunciado"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__theoretical_qty
 #: model:ir.model.fields.selection,name:stock_picking_mgmt_weight.selection__stock_move_weight_wizard__weight_selection__theoretical_qty
@@ -275,7 +272,6 @@ msgid "Cancelled Quantity"
 msgstr "Cantidad cancelada"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Cannot cancel pending quantities for %s: it's a classification order"
@@ -284,7 +280,6 @@ msgstr ""
 "clasificación"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid ""
@@ -295,7 +290,6 @@ msgstr ""
 "partir de pedidos de clasificación"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Cannot cancel pending quantities for %s: it's not an order yet"
@@ -303,7 +297,6 @@ msgstr ""
 "No se puede cancelar cantidades pendientes para %s: no es pedido todavía"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Cannot cancel pending quantities for %s: nothing is pending"
@@ -311,7 +304,6 @@ msgstr ""
 "No se puede cancelar cantidades pendientes para %s: no hay nada pendiente"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Cannot retrieve weight, an error was obtained. Please try again later"
@@ -436,7 +428,6 @@ msgid "Classification User"
 msgstr "Usuario de clasificación"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid ""
@@ -447,7 +438,6 @@ msgstr ""
 "asistente y verifíquelo"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Classification modification not allowed for you"
@@ -594,7 +584,6 @@ msgid "Created on"
 msgstr "Creado el"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Created when cancelling pending quantities of %s"
@@ -738,7 +727,6 @@ msgid "Gross weight date"
 msgstr "Fecha de peso bruto"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Gross weight too high (max. value=%.2f)"
@@ -868,8 +856,6 @@ msgstr "Pdte. facturar"
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
 #, python-format
@@ -878,8 +864,6 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
 #, python-format
@@ -888,8 +872,6 @@ msgstr "Cámara IoT"
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #, python-format
@@ -915,14 +897,12 @@ msgid "Is Default"
 msgstr "Por defecto"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "It is necessary to assign a scale to perform this operation."
 msgstr "Es necesario asignar una báscula para realizar esta operación."
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "It is necessary to assign a vehicle to perform this operation."
@@ -1014,10 +994,6 @@ msgid "Move Line Weight"
 msgstr "Líneas de clasificación"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_picking.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
@@ -1056,7 +1032,6 @@ msgstr "Nuevo parte de horas"
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/xml/iot_camera_field.xml:0
 #: code:addons/stock_picking_mgmt_weight/static/src/xml/iot_camera_field.xml:0
 #, python-format
 msgid "No Image"
@@ -1426,14 +1401,17 @@ msgid "Scale / Classification"
 msgstr "Báscula / Clasificación"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
+#: model:res.groups,name:stock_picking_mgmt_weight.group_sc_delete_ticket
+msgid "Scale / Classification: can delete ticket"
+msgstr "Báscula / Clasificación: permite eliminar tickets"
+
+#. module: stock_picking_mgmt_weight
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Scale Delivery Orders"
 msgstr "Órdenes de entrega de báscula"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Scale Receipts"
@@ -1450,7 +1428,6 @@ msgid "Scale Stock Move Count"
 msgstr "Contador de movimientos de inventario de la báscula"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: model:ir.model.fields.selection,name:stock_picking_mgmt_weight.selection__stock_move_weight_wizard__weight_selection__net_weight
 #, python-format
@@ -1470,14 +1447,12 @@ msgid "Scales"
 msgstr "Básculas"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Sequence Scale in"
 msgstr "Secuencia de báscula entrada"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Sequence Scale out"
@@ -1571,7 +1546,6 @@ msgid "Tare date"
 msgstr "Fecha de Tara"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Tare too high (max. value=%.2f)"
@@ -1598,13 +1572,6 @@ msgid "Technical field for sale order has pending quantity computation"
 msgstr ""
 "Campo técnico para el cálculo de si tiene cantidad pendiente el pedido de "
 "venta"
-
-#. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
-#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
-#, python-format
-msgid "The following weigh-in tickets are not allowed to be removed: %s"
-msgstr "No se permite eliminar los siguientes tickets de pesada: %s"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move__theoretical_qty
@@ -1767,7 +1734,6 @@ msgid "Type of Operation"
 msgstr "Tipo de operación"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/controllers/scale.py:0
 #: code:addons/stock_picking_mgmt_weight/controllers/scale.py:0
 #, python-format
 msgid "Undefined scale for current company"
@@ -1884,7 +1850,6 @@ msgid "Warehouse"
 msgstr "Almacén"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/sale_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/sale_order.py:0
 #, python-format
 msgid "Warning"
@@ -1925,7 +1890,6 @@ msgid "Weight Selection"
 msgstr "Selección de peso"
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Weight pending classification must be zero"
@@ -1947,6 +1911,26 @@ msgstr "Con vehículos asociados"
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_res_partner_vehicle_search_inherit
 msgid "Without associated vehicles"
 msgstr "Sin vehículos asociados"
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot delete the following weigh-in tickets because they have an "
+"assigned classification: %s"
+msgstr ""
+"No puede eliminar los siguientes tickets de pesada porque tienen una "
+"clasificación asignada: %s"
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid ""
+"You do not have sufficient permissions to delete the following weigh-in "
+"tickets: %s"
+msgstr ""
+"No tiene permisos suficientes para eliminar los siguientes tickets de "
+"pesada: %s"
 
 #. module: stock_picking_mgmt_weight
 #: model:ir.model,name:stock_picking_mgmt_weight.model_stock_move_line_weight_wizard

--- a/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
+++ b/stock_picking_mgmt_weight/i18n/stock_picking_mgmt_weight.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-05 08:12+0000\n"
-"PO-Revision-Date: 2025-11-05 08:12+0000\n"
+"POT-Creation-Date: 2025-12-03 09:03+0000\n"
+"PO-Revision-Date: 2025-12-03 09:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -57,14 +57,12 @@ msgid ""
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order_line.py:0
 #, python-format
 msgid "%s-%s (%.2f pend.)"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "/weight_images/%s"
@@ -136,7 +134,6 @@ msgid "Announced"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: model:ir.model.fields,field_description:stock_picking_mgmt_weight.field_stock_move_weight_wizard__theoretical_qty
 #: model:ir.model.fields.selection,name:stock_picking_mgmt_weight.selection__stock_move_weight_wizard__weight_selection__theoretical_qty
@@ -249,14 +246,12 @@ msgid "Cancelled Quantity"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Cannot cancel pending quantities for %s: it's a classification order"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid ""
@@ -265,21 +260,18 @@ msgid ""
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Cannot cancel pending quantities for %s: it's not an order yet"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Cannot cancel pending quantities for %s: nothing is pending"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Cannot retrieve weight, an error was obtained. Please try again later"
@@ -402,7 +394,6 @@ msgid "Classification User"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid ""
@@ -411,7 +402,6 @@ msgid ""
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Classification modification not allowed for you"
@@ -558,7 +548,6 @@ msgid "Created on"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #, python-format
 msgid "Created when cancelling pending quantities of %s"
@@ -694,7 +683,6 @@ msgid "Gross weight date"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Gross weight too high (max. value=%.2f)"
@@ -822,8 +810,6 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_asm_field.js:0
 #, python-format
@@ -832,8 +818,6 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_camera_field.js:0
 #, python-format
@@ -842,8 +826,6 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #: code:addons/stock_picking_mgmt_weight/static/src/js/iot_weight_field.js:0
 #, python-format
@@ -869,14 +851,12 @@ msgid "Is Default"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "It is necessary to assign a scale to perform this operation."
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "It is necessary to assign a vehicle to perform this operation."
@@ -968,10 +948,6 @@ msgid "Move Line Weight"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/purchase_order.py:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_picking.py:0
 #: code:addons/stock_picking_mgmt_weight/models/purchase_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
@@ -1010,7 +986,6 @@ msgstr ""
 
 #. module: stock_picking_mgmt_weight
 #. openerp-web
-#: code:addons/slv-stock/stock_picking_mgmt_weight/static/src/xml/iot_camera_field.xml:0
 #: code:addons/stock_picking_mgmt_weight/static/src/xml/iot_camera_field.xml:0
 #, python-format
 msgid "No Image"
@@ -1378,14 +1353,17 @@ msgid "Scale / Classification"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
+#: model:res.groups,name:stock_picking_mgmt_weight.group_sc_delete_ticket
+msgid "Scale / Classification: can delete ticket"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Scale Delivery Orders"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Scale Receipts"
@@ -1402,7 +1380,6 @@ msgid "Scale Stock Move Count"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: model:ir.model.fields.selection,name:stock_picking_mgmt_weight.selection__stock_move_weight_wizard__weight_selection__net_weight
 #, python-format
@@ -1422,14 +1399,12 @@ msgid "Scales"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Sequence Scale in"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_warehouse.py:0
 #, python-format
 msgid "Sequence Scale out"
@@ -1523,7 +1498,6 @@ msgid "Tare date"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
 #: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
 #, python-format
 msgid "Tare too high (max. value=%.2f)"
@@ -1547,13 +1521,6 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model:ir.model.fields,help:stock_picking_mgmt_weight.field_sale_order_line__has_pending_qty
 msgid "Technical field for sale order has pending quantity computation"
-msgstr ""
-
-#. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/stock_move.py:0
-#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
-#, python-format
-msgid "The following weigh-in tickets are not allowed to be removed: %s"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
@@ -1710,7 +1677,6 @@ msgid "Type of Operation"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/controllers/scale.py:0
 #: code:addons/stock_picking_mgmt_weight/controllers/scale.py:0
 #, python-format
 msgid "Undefined scale for current company"
@@ -1827,7 +1793,6 @@ msgid "Warehouse"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/models/sale_order.py:0
 #: code:addons/stock_picking_mgmt_weight/models/sale_order.py:0
 #, python-format
 msgid "Warning"
@@ -1868,7 +1833,6 @@ msgid "Weight Selection"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight
-#: code:addons/slv-stock/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #: code:addons/stock_picking_mgmt_weight/wizards/move_weight.py:0
 #, python-format
 msgid "Weight pending classification must be zero"
@@ -1889,6 +1853,22 @@ msgstr ""
 #. module: stock_picking_mgmt_weight
 #: model_terms:ir.ui.view,arch_db:stock_picking_mgmt_weight.view_res_partner_vehicle_search_inherit
 msgid "Without associated vehicles"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot delete the following weigh-in tickets because they have an "
+"assigned classification: %s"
+msgstr ""
+
+#. module: stock_picking_mgmt_weight
+#: code:addons/stock_picking_mgmt_weight/models/stock_move.py:0
+#, python-format
+msgid ""
+"You do not have sufficient permissions to delete the following weigh-in "
+"tickets: %s"
 msgstr ""
 
 #. module: stock_picking_mgmt_weight

--- a/stock_picking_mgmt_weight/models/stock_move.py
+++ b/stock_picking_mgmt_weight/models/stock_move.py
@@ -101,12 +101,19 @@ class StockMoveBackend(models.Model):
         return self.product_uom._compute_quantity(weight_value, uom_kg)
 
     def unlink(self):
-        if self.filtered(lambda x: x.picking_type_id.scale and x.net_weight):
-            move_ids = ', '.join(map(lambda x: x.picking_id.name, self.filtered(lambda x: x.picking_type_id.scale)))
+        scale_moves = self.filtered(lambda x: x.picking_type_id.scale and x.net_weight)
+
+        if scale_moves and not self.env.user.has_group("stock_picking_mgmt_weight.group_sc_delete_ticket"):
+            move_ids = ", ".join(scale_moves.mapped("picking_id.name"))
             raise ValidationError(
-                _("The following weigh-in tickets are not allowed to be removed: %s") % move_ids
+                _("You do not have sufficient permissions to delete the following weigh-in tickets: %s") % move_ids
             )
-        return super(StockMoveBackend, self).unlink()
+        pickings_to_unlink = scale_moves.mapped("picking_id")
+        res = super(StockMoveBackend, self).unlink()
+        if pickings_to_unlink:
+            pickings_to_unlink.unlink()
+
+        return res
 
 class StockMovFrontend(models.Model):
     # This section only applies to frontend additions (custom move views)
@@ -472,3 +479,13 @@ class StockMovFrontend(models.Model):
             or
             pick.purchase_id.propagate_custom_date
         )
+
+    def unlink(self):
+        classified_move_ids = self.filtered(lambda x: x.classification_purchase_order_id)
+        if classified_move_ids:
+            move_ids = ', '.join(map(lambda x: x.picking_id.name, classified_move_ids))
+            raise ValidationError(
+                _("You cannot delete the following weigh-in tickets because they have an assigned classification: %s") % move_ids
+            )
+
+        return super(StockMovFrontend, self).unlink()

--- a/stock_picking_mgmt_weight/security/stock_picking_mgmt_weight_security.xml
+++ b/stock_picking_mgmt_weight/security/stock_picking_mgmt_weight_security.xml
@@ -44,6 +44,19 @@
                 eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
             />
         </record>
+
+        <record id="group_sc_delete_ticket" model="res.groups">
+            <field name="name">Scale / Classification: can delete ticket</field>
+            <field name="category_id" ref="base.module_category_usability"/>
+            <field
+                name="implied_ids"
+                eval="[(4, ref('stock_picking_mgmt_weight.group_sc_manager'))]"
+            />
+            <field
+                name="users"
+                eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+            />
+        </record>
     </data>
     <data noupdate="1">
         <!-- For scale/classification users, ensure that the can see every


### PR DESCRIPTION
[IMP] stock_picking_mgmt_weight: improved deletion rules for weigh-in tickets
Modified unlink behavior to:
- Prevent deletion of weigh-in tickets with assigned classification.
- Restrict deletion of weigh-in tickets to users with proper permissions.

[IMP] logistics_planning_mgmt_weight: prevent deletion of weigh-in tickets with assigned logitics schedule