### PR TITLE
[13.0][FIX] stock_production_lot_available_at_date: subtract production consumption in lot availability // cover negatives

### DIFF
--- a/stock_production_lot_available_at_date/__manifest__.py
+++ b/stock_production_lot_available_at_date/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "category": "Warehouse",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": ["stock"],

--- a/stock_production_lot_available_at_date/report/report_stock_production_lot_at_date.py
+++ b/stock_production_lot_available_at_date/report/report_stock_production_lot_at_date.py
@@ -47,13 +47,13 @@ class ReportStockProductionLotDate(models.TransientModel):
                 sml.company_id,
                 SUM(
                     CASE
-                        WHEN sl_src.usage = 'production' THEN sml.qty_done
+                        WHEN sl_src.usage IN ('customer', 'production', 'inventory') THEN sml.qty_done
                         ELSE 0
                     END
                 ) -
                 SUM(
                     CASE
-                        WHEN sl_dest.usage = 'customer' THEN sml.qty_done
+                        WHEN sl_dest.usage IN ('customer', 'production', 'inventory') THEN sml.qty_done
                         ELSE 0
                     END
                 ) AS net_qty
@@ -66,19 +66,20 @@ class ReportStockProductionLotDate(models.TransientModel):
             JOIN product_template pt ON pt.id = pp.product_tmpl_id
             WHERE {where_clause}
             GROUP BY sml.lot_id, pp.id, sml.company_id, sml.product_uom_id
-            HAVING
+            HAVING ABS(
                 SUM(
                     CASE
-                        WHEN sl_src.usage = 'production' THEN sml.qty_done
+                        WHEN sl_src.usage IN ('customer', 'production', 'inventory') THEN sml.qty_done
                         ELSE 0
                     END
                 ) -
                 SUM(
                     CASE
-                        WHEN sl_dest.usage = 'customer' THEN sml.qty_done
+                        WHEN sl_dest.usage IN ('customer', 'production', 'inventory') THEN sml.qty_done
                         ELSE 0
                     END
-                ) > 0
+                )
+            ) >= 0.001
         """
 
         self.env.cr.execute(sql_query)


### PR DESCRIPTION
Include moves with destination usage production as consumed quantity when computing lot availability at a given date. This ensures production inputs are properly deducted from historical lot stock.

And also adds negative quant coverage (before this, only positive stocks were covered)