### PR TITLE
[13.0][IMP] stock_valuation: purchase returns at date support

### DIFF
--- a/stock_valuation/__manifest__.py
+++ b/stock_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.4.1",
+    "version": "13.0.3.5.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [
@@ -24,6 +24,7 @@
         "views/product_history_average_price_views.xml",
         "views/product_average_price_views.xml",
         "views/product_template_views.xml",
+        "views/stock_picking_views.xml",
         "views/stock_quant_views.xml",
         "views/res_config_settings_views.xml",
         "wizards/phap_price_edit_views.xml",

--- a/stock_valuation/i18n/es.po
+++ b/stock_valuation/i18n/es.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-21 09:11+0000\n"
-"PO-Revision-Date: 2024-06-21 11:12+0200\n"
+"POT-Creation-Date: 2025-12-17 09:08+0000\n"
+"PO-Revision-Date: 2025-12-17 10:19+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: \n"
-"X-Generator: Poedit 3.0.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_average_price__stock_zero
@@ -45,8 +45,20 @@ msgid ""
 "        - internal - internal transfer\n"
 "        - adjustment - Inventory adjustment\n"
 "        - scrap - Scrap\n"
+"        - mrp - comes from a production\n"
+"        - unbuild - comes from an unbuild\n"
 "        "
 msgstr ""
+"\n"
+"        Posibles tipos:\n"
+"        - purchase - compra o devolución de una compra\n"
+"        - sale - venta o devolución de una venta\n"
+"        - internal - transferencia interna\n"
+"        - adjustment - ajuste de inventario\n"
+"        - scrap - desecho\n"
+"        - mrp - Producción\n"
+"        - unbuild - Despiece\n"
+"        "
 
 #. module: stock_valuation
 #: code:addons/stock_valuation/models/product_average_price.py:0
@@ -297,6 +309,14 @@ msgstr "Precio medio actual"
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__stock_quantity
 msgid "Current stock quantity"
 msgstr "Cantidad en stock actual"
+
+#. module: stock_valuation
+#: code:addons/stock_valuation/models/stock_picking.py:0
+#, python-format
+msgid "Customer return date for %s cannot be prior than original returned %s date"
+msgstr ""
+"La fecha personalizada de devolución para %s no puede ser anterior a la fecha del %s que se "
+"retorna"
 
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date__date
@@ -650,7 +670,7 @@ msgstr "Movimientos de Producto (Líneas de movimiento)"
 #. module: stock_valuation
 #: model:ir.model,name:stock_valuation.model_product_template
 msgid "Product Template"
-msgstr "Producto"
+msgstr "Plantilla de producto"
 
 #. module: stock_valuation
 #: model:ir.model.fields.selection,name:stock_valuation.selection__stock_valuation_layer__origin_type__purchase
@@ -679,6 +699,11 @@ msgid "Reference"
 msgstr "Referencia"
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_picking_form
+msgid "Return Date"
+msgstr "Fecha de devolución"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr "Error de envío de SMS"
@@ -702,6 +727,11 @@ msgstr "Buscar"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
 msgid "Selected warehouses"
 msgstr "Almacenes seleccionados"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_picking_form
+msgid "Set Cust. Ret. Date"
+msgstr "Asig. fec. devol. pers."
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.res_config_settings_view_form
@@ -805,6 +835,11 @@ msgid "Total inputs"
 msgstr "Total entradas"
 
 #. module: stock_valuation
+#: model:ir.model,name:stock_valuation.model_stock_picking
+msgid "Transfer"
+msgstr "Albarán"
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__origin_type
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_search_inherit
 msgid "Type"
@@ -819,6 +854,26 @@ msgstr "Mensajes no leídos"
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread_counter
 msgid "Unread Messages Counter"
 msgstr "Contador de mensajes no leídos"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__val_cust_ret_date
+msgid "Valuation - Customer Return Date"
+msgstr "Valoración - Fecha personalizada de devolución"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__has_val_cust_ret_date_enabled
+msgid "Valuation - Customer Return Date Enabled"
+msgstr "Valoración - Fecha personalizada de devolución habilitada"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__has_val_cust_ret_date_visible
+msgid "Valuation - Customer Return Date Visible"
+msgstr "Valoración - Fecha personalizada de devolución visible"
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__has_val_cust_ret_date
+msgid "Valuation - Has Customer Return Date"
+msgstr "Valoración - Tiene fecha personalizada de devolución"
 
 #. module: stock_valuation
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_form_inherit
@@ -865,6 +920,16 @@ msgstr "Mensajes del sitio web"
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__website_message_ids
 msgid "Website communication history"
 msgstr "Historial de comunicación del website"
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_picking_form
+msgid ""
+"When enabled, for valuation purposes a custom return                         date can be set; "
+"otherwise, original incoming date will be used"
+msgstr ""
+"Cuando está establecido, para temas de valoración se puede establecer "
+"una                         fecha personalizada; de no establecerse se aplicará la fecha de la "
+"entrada original"
 
 #. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__average_price_manual_dt

--- a/stock_valuation/i18n/stock_valuation.pot
+++ b/stock_valuation/i18n/stock_valuation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-21 09:11+0000\n"
-"PO-Revision-Date: 2024-06-21 09:11+0000\n"
+"POT-Creation-Date: 2025-12-17 09:08+0000\n"
+"PO-Revision-Date: 2025-12-17 09:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -37,6 +37,8 @@ msgid ""
 "        - internal - internal transfer\n"
 "        - adjustment - Inventory adjustment\n"
 "        - scrap - Scrap\n"
+"        - mrp - comes from a production\n"
+"        - unbuild - comes from an unbuild\n"
 "        "
 msgstr ""
 
@@ -272,6 +274,13 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_phap_qty_edit_wizard__stock_quantity
 msgid "Current stock quantity"
+msgstr ""
+
+#. module: stock_valuation
+#: code:addons/stock_valuation/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Customer return date for %s cannot be prior than original returned %s date"
 msgstr ""
 
 #. module: stock_valuation
@@ -651,6 +660,11 @@ msgid "Reference"
 msgstr ""
 
 #. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_picking_form
+msgid "Return Date"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr ""
@@ -673,6 +687,11 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_average_price_date_wizard__warehouse_ids
 msgid "Selected warehouses"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_picking_form
+msgid "Set Cust. Ret. Date"
 msgstr ""
 
 #. module: stock_valuation
@@ -775,6 +794,11 @@ msgid "Total inputs"
 msgstr ""
 
 #. module: stock_valuation
+#: model:ir.model,name:stock_valuation.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_stock_valuation_layer__origin_type
 #: model_terms:ir.ui.view,arch_db:stock_valuation.view_stock_valuation_layer_search_inherit
 msgid "Type"
@@ -788,6 +812,26 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,field_description:stock_valuation.field_product_history_average_price__message_unread_counter
 msgid "Unread Messages Counter"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__val_cust_ret_date
+msgid "Valuation - Customer Return Date"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__has_val_cust_ret_date_enabled
+msgid "Valuation - Customer Return Date Enabled"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__has_val_cust_ret_date_visible
+msgid "Valuation - Customer Return Date Visible"
+msgstr ""
+
+#. module: stock_valuation
+#: model:ir.model.fields,field_description:stock_valuation.field_stock_picking__has_val_cust_ret_date
+msgid "Valuation - Has Customer Return Date"
 msgstr ""
 
 #. module: stock_valuation
@@ -834,6 +878,14 @@ msgstr ""
 #. module: stock_valuation
 #: model:ir.model.fields,help:stock_valuation.field_product_history_average_price__website_message_ids
 msgid "Website communication history"
+msgstr ""
+
+#. module: stock_valuation
+#: model_terms:ir.ui.view,arch_db:stock_valuation.view_picking_form
+msgid ""
+"When enabled, for valuation purposes a custom return"
+"                         date can be set; otherwise, original incoming date "
+"will be used"
 msgstr ""
 
 #. module: stock_valuation

--- a/stock_valuation/models/__init__.py
+++ b/stock_valuation/models/__init__.py
@@ -7,6 +7,7 @@ from . import stock_move_line
 from . import product_template
 from . import product_product
 from . import purchase_order_line
+from . import stock_picking
 from . import stock_quant
 from . import res_company
 from . import res_config_settings

--- a/stock_valuation/models/stock_move.py
+++ b/stock_valuation/models/stock_move.py
@@ -154,7 +154,12 @@ class StockMove(models.Model):
                 )
                 # We're in a single picking, so first move is enough
                 #  for getting this information
-                out_date = out_moves[0].origin_returned_move_id.date
+                # Custom date, if filled, is mandatory anyway
+                out_date = (
+                    pick.has_val_cust_ret_date
+                    and pick.val_cust_ret_date
+                    or out_moves[0].origin_returned_move_id.date
+                )
                 out_moves = out_moves.with_context(
                     stock_move_custom_date=out_date
                 )

--- a/stock_valuation/models/stock_picking.py
+++ b/stock_valuation/models/stock_picking.py
@@ -1,0 +1,67 @@
+# © 2022 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    has_val_cust_ret_date = fields.Boolean(
+        string="Valuation - Has Customer Return Date",
+        default=False,
+    )
+    val_cust_ret_date = fields.Datetime(
+        string="Valuation - Customer Return Date",
+        compute="_compute_val_cust_ret_date",
+        store=True,
+        readonly=False,
+    )
+    has_val_cust_ret_date_enabled = fields.Boolean(
+        string="Valuation - Customer Return Date Enabled",
+        compute="_compute_has_val_cust_ret_date_attrs",
+    )
+    has_val_cust_ret_date_visible = fields.Boolean(
+        string="Valuation - Customer Return Date Visible",
+        compute="_compute_has_val_cust_ret_date_attrs",
+    )
+
+    @api.depends("has_val_cust_ret_date")
+    def _compute_val_cust_ret_date(self):
+        # When has_val_cust_ret_date is set, if there's no value yet, current date is set
+        # When has_val_cust_ret_date is unset, the value is cleared
+        pick_cust_date = self.filtered(lambda x: x.has_val_cust_ret_date)
+        pick_cust_date_empty = self.filtered(
+            lambda x: not x.val_cust_ret_date
+        )
+        pick_cust_date_empty.update({"val_cust_ret_date": fields.Datetime.now()})
+        (self - pick_cust_date).update({"val_cust_ret_date": False})
+
+    @api.depends("picking_type_code", "move_lines.purchase_line_id", "state")
+    def _compute_has_val_cust_ret_date_attrs(self):
+        for picking in self:
+            # We'll only enable fill a custom return date for in-process incoming returns
+            picking.has_val_cust_ret_date_visible = (
+                picking.picking_type_code == "outgoing"
+                and picking.move_lines.purchase_line_id   # and picking.move_lines.origin_returned_move_id
+            )
+            picking.has_val_cust_ret_date_enabled = (
+                picking.has_val_cust_ret_date_visible
+                and not picking.state in ["done", "cancel"]
+            )
+
+    @api.constrains("val_cust_ret_date")
+    def _check_val_cust_ret_date(self):
+        for picking in self.filtered(lambda x: x.has_val_cust_ret_date):
+            purchase_order_id = picking.move_lines.purchase_line_id.order_id
+            if purchase_order_id and purchase_order_id.date_order > picking.val_cust_ret_date:
+                raise ValidationError(
+                    _(
+                        "Customer return date for %s cannot be prior than"
+                        " original returned %s date"
+                    ) % (
+                        picking.name,
+                        purchase_order_id.name,
+                    )
+                )            

--- a/stock_valuation/models/stock_valuation_layer.py
+++ b/stock_valuation/models/stock_valuation_layer.py
@@ -161,9 +161,12 @@ class StockValuationLayer(models.Model):
                         # TODO this should be return always a value,
                         #  but False is possible!!!
                         # vals["history_average_price_id"] = orig_move.get_phap_id()
-                        vals["history_average_price_id"] = (
-                            move_id.origin_returned_move_id.stock_valuation_layer_ids.history_average_price_id.id
-                        )
+                        # PHAP assigned is only forced if we're stringly linked with origin return move date
+                        #  (in other words, if no custom return date is set)
+                        if not move_id.picking_id.has_val_cust_ret_date:
+                            vals["history_average_price_id"] = (
+                                move_id.origin_returned_move_id.stock_valuation_layer_ids.history_average_price_id.id
+                            )
 
                 elif move_id.picking_type_id.code == 'internal':
                     vals["value"] = vals.get("unit_cost") * vals.get("quantity")

--- a/stock_valuation/views/stock_picking_views.xml
+++ b/stock_valuation/views/stock_picking_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form (in stock_valuation)</field>
+        <field name="model">stock.picking</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_picking_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date_done']" position="after">
+                <field name="has_val_cust_ret_date_enabled" invisible="1" />
+                <field name="has_val_cust_ret_date_visible" invisible="1" />
+                <field
+                    name="has_val_cust_ret_date"
+                    string="Set Cust. Ret. Date"
+                    attrs="{
+                        'readonly': [('has_val_cust_ret_date_enabled', '=', False)],
+                        'invisible': [('has_val_cust_ret_date_visible', '=', False)],
+                    }"                    
+                    help="
+                        When enabled, for valuation purposes a custom return
+                        date can be set; otherwise, original incoming date will be used
+                    "
+                />
+                <field
+                    name="val_cust_ret_date"
+                    string="Return Date"
+                    attrs="{
+                        'required': [('has_val_cust_ret_date', '=', True)],
+                        'readonly': [('state', 'in', ['done', 'cancel'])],
+                        'invisible': [('has_val_cust_ret_date', '=', False)],
+                    }"                    
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this improvement, every purchase return was linked to origin purchase incoming date. Their moves and valuations was indeed placed at origin moves date.

With this improvement, if another custom date is required, it's possible to set such date within picking return before validating it.

TODO

* [ ] Which average price should we pick, original one anyway, or new date based?
* [ ] Custom date should only be offered for those return picks that have at least one product with proper valuation method?
* [x] Translations