### PR TITLE
[17.0][FIX] stock_picking_mgmt_weight: missing invoice status extended management in purchase tree views

### DIFF
--- a/stock_picking_mgmt_weight/__manifest__.py
+++ b/stock_picking_mgmt_weight/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.2.2",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": [

--- a/stock_picking_mgmt_weight/views/purchase_order_views.xml
+++ b/stock_picking_mgmt_weight/views/purchase_order_views.xml
@@ -213,11 +213,15 @@
                 />
             </field>
             <field name="invoice_status" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </field>
             <field name="invoice_status" position="after">
                 <field
                     name="invoice_status_ext"
+                    widget="badge"
+                    decoration-success="invoice_status_ext == 'invoiced'"
+                    decoration-warning="invoice_status_ext == 'to invoice classif'"
+                    decoration-info="invoice_status_ext == 'to invoice'"
                     optional="show"
                 />
             </field>


### PR DESCRIPTION
Invoice status and Invoice status extended field for purchase orders was managed in one of the purchase tree views and missing for the another one. This fixes it.