### PR TITLE
[13.0][FIX] logistics_planning_purchase: enable initial required schedules at POL form view

### DIFF
--- a/logistics_planning_purchase/__manifest__.py
+++ b/logistics_planning_purchase/__manifest__.py
@@ -7,7 +7,7 @@
     ''',
     'author': 'Solvos',
     'license': 'LGPL-3',
-    'version': '13.0.1.7.0',
+    'version': '13.0.1.7.1',
     'category': 'stock',
     'website': 'https://github.com/solvosci/slv-stock',
     "depends": [

--- a/logistics_planning_purchase/views/purchase_order_views.xml
+++ b/logistics_planning_purchase/views/purchase_order_views.xml
@@ -76,6 +76,14 @@
                     name="logistics_price_unit" widget="monetary"
                     attrs="{'invisible': [('logistics_schedule_skip', '=', True)]}"
                 />
+                <field
+                    name="logistics_schedule_init"
+                    attrs="{'invisible': [
+                        '|',
+                        ('logistics_schedule_skip', '=', True),
+                        ('state', 'in', ['purchase', 'done', 'cancel']),
+                    ]}"
+                />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='taxes_id']"


### PR DESCRIPTION
Before this, if a user could only edit a purchase line using inner form view, he couldn't edit initial required schedules, and eventually confirm the PO (e.g. at responsive mode). This fixes it.

HT01191